### PR TITLE
feat(backup): optional nightly DB backup to one admin's DM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,5 +54,14 @@ AI_URL=http://...
 AI_SESSION_ID=123456789
 AI_INTERVAL=5
 
+# --- Nightly DB backup to one admin's DM (optional, OFF by default) ---
+# When BACKUP_ADMIN_ID is set to one of the ADMINS ids above, the bot sends the
+# newest DB backup file to THAT chat (and only that chat — it never broadcasts)
+# once a day at BACKUP_TIME (Asia/Tehran, default 02:00). Leave BACKUP_ADMIN_ID
+# empty to disable. A non-ADMINS id is rejected at startup (guards against a typo
+# shipping the DB to the wrong chat).
+BACKUP_ADMIN_ID=
+BACKUP_TIME=02:17
+
 # --- Misc ---
 DONATION_LINK="https://daramet.com/Chevalet"

--- a/internal/bot/admin.go
+++ b/internal/bot/admin.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -303,20 +302,17 @@ func (b *Bot) adminReport(ctx *ext.Context, dbctx context.Context, text []string
 }
 
 // adminBackup ports the /admin backup branch: send the newest file in backups/.
+// Selection is by mtime via latestBackupFile (shared with the nightly job); the
+// original plain name sort could be fooled by a differently-prefixed file into
+// returning a stale dump.
 func (b *Bot) adminBackup(tg *gotgbot.Bot, ctx *ext.Context) error {
-	entries, err := os.ReadDir("backups")
+	latest, err := latestBackupFile("backups", 0) // 0 = newest right now (manual command)
 	if err != nil {
 		return err
 	}
-	names := make([]string, 0, len(entries))
-	for _, e := range entries {
-		names = append(names, e.Name())
+	if latest == "" {
+		return errWrongSyntax // no backup yet -> Python's backups[-1] IndexError path
 	}
-	if len(names) == 0 {
-		return errWrongSyntax // Python's backups[-1] would IndexError -> wrong syntax
-	}
-	sort.Strings(names)
-	latest := names[len(names)-1]
 	f, err := os.Open(filepath.Join("backups", latest))
 	if err != nil {
 		return err

--- a/internal/bot/background.go
+++ b/internal/bot/background.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -38,6 +39,10 @@ func (b *Bot) startBackground(ctx context.Context) {
 	if b.Cfg.SendGMGN {
 		b.goBG(func() { b.gmgnLoop(ctx, b.Cfg.GMTime, true) })  // morning
 		b.goBG(func() { b.gmgnLoop(ctx, b.Cfg.GNTime, false) }) // night
+	}
+	// Nightly DB backup to one admin's DM — off unless BACKUP_ADMIN_ID is set.
+	if b.Cfg.BackupAdminID != 0 {
+		b.goBG(func() { b.backupLoop(ctx, b.Cfg.BackupTime, b.Cfg.BackupAdminID) })
 	}
 }
 
@@ -152,6 +157,117 @@ func (b *Bot) sendGMGN(isMorning bool) {
 	if _, err := b.TG.SendMessage(gid, text, opts); err != nil {
 		slog.Warn("send_gm_gn failed", "err", err)
 	}
+}
+
+// latestBackupFile returns the name of the most-recently-MODIFIED file in dir
+// (newest by mtime — robust to mixed file-name prefixes, unlike a plain name
+// sort), or "" when dir holds no eligible file. Shared by /admin backup and the
+// nightly delivery so both always pick the truly newest dump.
+//
+// minAge skips any file younger than it: the hourly backup.sh gzips straight
+// into the final filename (no temp+rename), so a file written seconds ago may be
+// a dump still in progress — sending it would ship a truncated, un-gunzippable
+// archive that Telegram accepts and we'd log as "sent". The scheduled path passes
+// a few minutes (an older hourly dump always exists); the manual /admin backup
+// passes 0 to keep its exact "newest file, right now" semantics.
+func latestBackupFile(dir string, minAge time.Duration) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	var newest string
+	var newestT time.Time
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		mt := info.ModTime()
+		if minAge > 0 && time.Since(mt) < minAge {
+			continue // too fresh — may be a dump still being written
+		}
+		// Newest by mtime; on an mtime tie, the lexicographically larger name
+		// wins (matches the old name-sort's "last wins", stable after a restore
+		// that flattens mtimes).
+		if newest == "" || mt.After(newestT) || (mt.Equal(newestT) && e.Name() > newest) {
+			newest, newestT = e.Name(), mt
+		}
+	}
+	return newest, nil
+}
+
+// backupLoop delivers the newest DB backup to the configured admin's DM once a
+// day at hm (Asia/Tehran), mirroring gmgnLoop's daily-scheduler shape. It is
+// launched only when a valid BackupAdminID is configured (see startBackground),
+// so it can never run — or reach any chat other than that one id — by default.
+func (b *Bot) backupLoop(ctx context.Context, hm [2]int, adminID int64) {
+	loc, err := time.LoadLocation("Asia/Tehran")
+	if err != nil {
+		slog.Error("backup: cannot load Asia/Tehran", "err", err)
+		loc = time.UTC
+	}
+	for {
+		now := time.Now().In(loc)
+		next := time.Date(now.Year(), now.Month(), now.Day(), hm[0], hm[1], 0, 0, loc)
+		if !next.After(now) {
+			next = next.AddDate(0, 0, 1)
+		}
+		timer := time.NewTimer(time.Until(next))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+			b.sendLatestBackupTo(adminID)
+		}
+	}
+}
+
+// backupMinAge is how long a backup file must have existed before the nightly
+// job will send it, so it can never grab an hourly dump mid-write (see
+// latestBackupFile). An older hourly backup always exists, so this never starves.
+const backupMinAge = 3 * time.Minute
+
+// sendLatestBackupTo sends the newest settled backups/ file to a SINGLE chat id
+// (the nightly admin DM). Best-effort — every failure is logged, never fatal —
+// and it targets exactly one chat: it never iterates users / never broadcasts.
+// On any failure it also pings that same chat with a short text so a silent
+// stall (e.g. the dump one day exceeds Telegram's 50MB bot limit) is noticed.
+func (b *Bot) sendLatestBackupTo(chatID int64) {
+	latest, err := latestBackupFile("backups", backupMinAge)
+	if err != nil || latest == "" {
+		slog.Warn("nightly backup: no file to send", "err", err)
+		b.notifyBackupFail(chatID, "فایلِ بکاپی پیدا نشد")
+		return
+	}
+	f, err := os.Open(filepath.Join("backups", latest))
+	if err != nil {
+		slog.Warn("nightly backup: open failed", "file", latest, "err", err)
+		b.notifyBackupFail(chatID, "بازکردنِ فایلِ بکاپ نشد")
+		return
+	}
+	defer f.Close()
+	// A DB dump can outgrow the 10s default request timeout as the data grows;
+	// give the upload its own generous budget so it scales with the file.
+	if _, err := b.TG.SendDocument(chatID, gotgbot.InputFileByReader(latest, f),
+		&gotgbot.SendDocumentOpts{
+			Caption:     "🌙 بکاپِ خودکارِ شبانه‌ی دیتابیس — " + latest,
+			RequestOpts: &gotgbot.RequestOpts{Timeout: 120 * time.Second},
+		}); err != nil {
+		slog.Warn("nightly backup: send failed", "to", chatID, "err", err)
+		b.notifyBackupFail(chatID, "ارسالِ فایل ناموفق بود (شاید حجمش از حدِ تلگرام بیشتر شده)")
+		return
+	}
+	slog.Info("nightly backup sent", "to", chatID, "file", latest)
+}
+
+// notifyBackupFail best-effort tells the admin chat the nightly backup didn't go
+// through, so absence-of-file is never mistaken for "nothing to back up".
+func (b *Bot) notifyBackupFail(chatID int64, reason string) {
+	_, _ = b.TG.SendMessage(chatID, "⚠️ بکاپِ خودکارِ شبانه ارسال نشد: "+reason, nil)
 }
 
 // aiResponderLoop ports jobs.ai_responser: it drains the GM-group AI queue one

--- a/internal/bot/backup_test.go
+++ b/internal/bot/backup_test.go
@@ -1,0 +1,65 @@
+package bot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestLatestBackupFile locks the selection rules: newest by MTIME (not name),
+// directories skipped, and the min-age guard that keeps the nightly job from
+// grabbing an hourly dump still being written.
+func TestLatestBackupFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// empty dir -> "" (the /admin backup "no backup yet" path)
+	if got, err := latestBackupFile(dir, 0); err != nil || got != "" {
+		t.Fatalf("empty dir: got (%q,%v); want (\"\",nil)", got, err)
+	}
+
+	mk := func(name string, age time.Duration) {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		mt := time.Now().Add(-age)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("backup_mydatabase_20260708_140001.sql.gz", 10*time.Minute) // newest SETTLED
+	mk("backup_mydatabase_20260708_130001.sql.gz", 2*time.Hour)
+	mk("zzz-predeploy-20260706.sql.gz", 48*time.Hour) // lexicographically last but OLDEST
+
+	// a subdirectory (even with a brand-new mtime) must never be returned.
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// minAge 0: newest by mtime, ignoring the stale lexicographically-last file
+	// and the subdir.
+	got, err := latestBackupFile(dir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "backup_mydatabase_20260708_140001.sql.gz" {
+		t.Errorf("latestBackupFile(0) = %q; want the newest-by-mtime file (not the stale lex-last one or a subdir)", got)
+	}
+
+	// min-age guard: a just-written (in-progress) dump must be skipped, so the
+	// newest SETTLED file is returned instead.
+	mk("backup_mydatabase_20260708_150001.sql.gz", 0) // written "now" — too fresh
+	got, err = latestBackupFile(dir, 3*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "backup_mydatabase_20260708_140001.sql.gz" {
+		t.Errorf("latestBackupFile(3m) = %q; want the newest SETTLED file, skipping the just-written one", got)
+	}
+
+	// missing dir -> error surfaces
+	if _, err := latestBackupFile(filepath.Join(dir, "does-not-exist"), 0); err == nil {
+		t.Error("missing dir: want an error, got nil")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,13 @@ type Config struct {
 	GMGroupID    string
 	GMGroupTopic string
 
+	// Optional nightly DB-backup delivery: once a day at BackupTime (Asia/Tehran)
+	// the newest backups/ file is sent to the single chat BackupAdminID. The whole
+	// job is OFF when BackupAdminID == 0 (env BACKUP_ADMIN_ID unset), so it never
+	// runs — and never broadcasts — unless explicitly configured.
+	BackupAdminID int64
+	BackupTime    [2]int
+
 	AIURL       string
 	AISessionID string
 	AIInterval  int
@@ -186,6 +193,30 @@ func Load() (*Config, error) {
 	c.GNTime = parseHHMM("GN_TIME", req("GN_TIME"), &errs)
 	c.GMGroupID = req("GM_GROUP_ID")
 
+	// Optional nightly-backup-to-admin job. Both keys are optional: the feature is
+	// off unless BACKUP_ADMIN_ID is a valid ADMINS id. BACKUP_TIME defaults to
+	// 02:17 (Asia/Tehran) — a quiet end-of-night snapshot, deliberately off the
+	// hourly backup cron's ":00" minute (belt-and-suspenders on top of the
+	// send-path's min-age guard).
+	c.BackupTime = [2]int{2, 17}
+	if v := opt("BACKUP_TIME", ""); v != "" {
+		c.BackupTime = parseHHMM("BACKUP_TIME", v, &errs)
+	}
+	if v := opt("BACKUP_ADMIN_ID", ""); v != "" {
+		n, perr := strconv.ParseInt(v, 10, 64)
+		switch {
+		case perr != nil:
+			errs = append(errs, fmt.Sprintf("BACKUP_ADMIN_ID must be an integer (got %q)", v))
+		case !adminIDAllowed(c.Admins, v):
+			// Must be a trusted ADMINS member: a typo must NOT silently ship the
+			// full DB to a random user (or a negative group/channel id) every
+			// night. Fail loud at startup instead of exfiltrating quietly.
+			errs = append(errs, fmt.Sprintf("BACKUP_ADMIN_ID %q must be one of ADMINS %v", v, c.Admins))
+		default:
+			c.BackupAdminID = n
+		}
+	}
+
 	c.DonationLink = req("DONATION_LINK")
 
 	if len(missing) > 0 {
@@ -195,6 +226,17 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("config: %s", strings.Join(errs, "; "))
 	}
 	return c, nil
+}
+
+// adminIDAllowed reports whether id (a Telegram user-id string) is present in the
+// ADMINS list, tolerant of surrounding whitespace in the '|'-split entries.
+func adminIDAllowed(admins []string, id string) bool {
+	for _, a := range admins {
+		if strings.TrimSpace(a) == id {
+			return true
+		}
+	}
+	return false
 }
 
 // parseHHMM parses "HH:MM" into [hour, minute], mirroring config.py's

--- a/internal/config/config_backup_test.go
+++ b/internal/config/config_backup_test.go
@@ -1,0 +1,30 @@
+package config
+
+import "testing"
+
+// TestAdminIDAllowed locks the BACKUP_ADMIN_ID guard: only a genuine ADMINS
+// member is accepted, so a typo (or a group/channel id) can't arm a nightly
+// full-DB send to the wrong chat.
+func TestAdminIDAllowed(t *testing.T) {
+	admins := []string{"84581926", " 6857450344 ", "6082663084"} // note the padded entry
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"6857450344", true}, // matches the whitespace-padded ADMINS entry
+		{"84581926", true},
+		{"6082663084", true},
+		{"6857450340", false},     // single-digit typo -> rejected
+		{"-1001960197379", false}, // a group/channel id -> rejected
+		{"0", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := adminIDAllowed(admins, c.id); got != c.want {
+			t.Errorf("adminIDAllowed(%q) = %v; want %v", c.id, got, c.want)
+		}
+	}
+	if adminIDAllowed(nil, "6857450344") {
+		t.Error("adminIDAllowed(nil, ...) = true; want false (no admins configured)")
+	}
+}


### PR DESCRIPTION
Add a default-OFF scheduled job that, once a day at BACKUP_TIME (Asia/Tehran, default 02:17), sends the newest DB backup file to the single chat BACKUP_ADMIN_ID — the requesting admin's private chat. It never iterates users / never broadcasts, and is off unless BACKUP_ADMIN_ID is set to an ADMINS member.

- config: BACKUP_ADMIN_ID (must be an ADMINS id, else startup fails — a typo can't ship the DB to a wrong chat) + BACKUP_TIME ("HH:MM", default 02:17, off the hourly cron's :00 minute).
- bot: backupLoop (daily scheduler, same shape as gmgnLoop, ctx-cancellable, goBG-tracked); sendLatestBackupTo (one SendDocument to one chat, 120s upload timeout, pings the admin on any failure so a stall is noticed).
- latestBackupFile(dir, minAge): newest-by-mtime with a min-age guard so the nightly job never grabs an hourly dump still being written; /admin backup reuses it (minAge 0) — also fixes its latent name-sort-wrong-prefix bug.
- tests: latestBackupFile (mtime/min-age/subdir/empty/missing) + adminIDAllowed; .env.example documents both keys.

## Summary

<!-- What does this PR do and why? -->

## Type of change

- [ ] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `maint` — refactor / chore / dependency bump
- [ ] `docs` — documentation
- [ ] `ci` — build / CI

## Checklist

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `gofmt -l .` prints nothing
- [ ] `go test -race ./...` passes
- [ ] I did **not** change the `internal/encoder` cipher output (frozen contract)
- [ ] User-visible behavior changes are described above

## Notes for reviewers

<!-- Anything reviewers should pay special attention to. -->
