### PR TITLE
feat(security): encrypt callback tokens — fix S-0002 chevaletid linka…

### DIFF
--- a/internal/bot/autoreply.go
+++ b/internal/bot/autoreply.go
@@ -32,9 +32,9 @@ func (b *Bot) otherMessagesTemplate(ctx *ext.Context) error {
 
 // isAnswer ports handler_templates.is_answer. It inspects the replied-to
 // message: if that is one of the bot's delivered messages (carrying an "answer|"
-// button), it resolves the encoded target chevaletid and the original message
-// id. warnWrongReply controls the "you must reply to the anonymous message
-// itself" hint, exactly as the Python `_warn_wrong_reply` flag.
+// button), it resolves the target user id and the original message id.
+// warnWrongReply controls the "you must reply to the anonymous message itself"
+// hint, exactly as the Python `_warn_wrong_reply` flag.
 func (b *Bot) isAnswer(ctx *ext.Context, warnWrongReply bool) (answerKind, string, string, error) {
 	msg := ctx.EffectiveMessage
 	reply := msg.ReplyToMessage
@@ -53,7 +53,7 @@ func (b *Bot) isAnswer(ctx *ext.Context, warnWrongReply bool) (answerKind, strin
 					}
 					token, targetMid := parts[1], parts[2]
 					dbctx, cancel := b.bg()
-					chid, ok, err := b.handleCIDOrChID(dbctx, msg, token)
+					uid, ok, err := b.resolveTargetUID(dbctx, msg, token)
 					cancel()
 					if err != nil {
 						return answerNone, "", "", err
@@ -61,7 +61,7 @@ func (b *Bot) isAnswer(ctx *ext.Context, warnWrongReply bool) (answerKind, strin
 					if !ok {
 						return answerEnd, "", "", nil
 					}
-					return answerMatch, chid, targetMid, nil
+					return answerMatch, uid, targetMid, nil
 				}
 			}
 		}
@@ -130,7 +130,7 @@ func authorSignature(origin gotgbot.MessageOrigin) string {
 // an author-specific link when the post had an author signature, and resolves it
 // to a target. Returns answerNone (Python False, no external reply), answerEnd
 // (Python END), or answerMatch with (target_cid, encoded_chid).
-func (b *Bot) isReplyToChannel(ctx *ext.Context) (kind answerKind, targetCid, encChid string, err error) {
+func (b *Bot) isReplyToChannel(ctx *ext.Context) (kind answerKind, targetCid, uid string, err error) {
 	msg := ctx.EffectiveMessage
 	externalReply := msg.ExternalReply
 	if externalReply == nil || externalReply.Chat == nil {
@@ -198,19 +198,18 @@ func (b *Bot) isReplyToChannel(ctx *ext.Context) (kind answerKind, targetCid, en
 		return answerEnd, "", "", b.replyText(ctx, txtLinkDeletedOrChanged)
 	}
 
+	// Ensure the target still has a chevaletid (mint if missing) — preserves the
+	// original side effect for any legacy path that resolves by chevaletid.
 	targetChid, derr := b.DB.GetChevaletIDByUID(dbctx, targetUID)
 	if derr != nil {
 		return answerNone, "", "", derr
 	}
 	if targetChid == "" {
-		targetChid = encoder.GenerateChevaletID()
-		// As in handle_cid_or_chid: set_chevaletid always succeeded in Python, so
-		// a real failure propagates to the central error handler here.
-		if derr := b.DB.SetChevaletID(dbctx, targetUID, targetChid); derr != nil {
+		if derr := b.DB.SetChevaletID(dbctx, targetUID, encoder.GenerateChevaletID()); derr != nil {
 			return answerNone, "", "", derr
 		}
 	}
-	return answerMatch, targetCid, encoder.EncodeChevaletID(targetChid), nil
+	return answerMatch, targetCid, targetUID, nil
 }
 
 // reMatches reports whether re matches the lower-cased haystack (the Python code
@@ -254,7 +253,7 @@ func firstURLButtonCID(re *regexp.Regexp, keyboard [][]gotgbot.InlineKeyboardBut
 // the Python END return (something was handled); false falls through.
 func (b *Bot) checkIfAutoreply(ctx *ext.Context, userid string) (handled bool, err error) {
 	// private reply
-	kind, chid, mid, err := b.isAnswer(ctx, true)
+	kind, targetUID, mid, err := b.isAnswer(ctx, true)
 	if err != nil {
 		return false, err
 	}
@@ -264,7 +263,7 @@ func (b *Bot) checkIfAutoreply(ctx *ext.Context, userid string) (handled bool, e
 	if kind == answerMatch {
 		ud := b.ud(ctx)
 		ud.d.targetCid = ""
-		ud.d.targetChid = chid
+		ud.d.targetUID = targetUID
 		ud.d.replyTo = mid
 		ud.d.channelReply = false
 		if _, e := b.sendMsgTemplate(ctx, userid); e != nil {
@@ -274,7 +273,7 @@ func (b *Bot) checkIfAutoreply(ctx *ext.Context, userid string) (handled bool, e
 	}
 
 	// channel reply
-	ckind, cCid, cChid, err := b.isReplyToChannel(ctx)
+	ckind, cCid, cUID, err := b.isReplyToChannel(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -284,7 +283,7 @@ func (b *Bot) checkIfAutoreply(ctx *ext.Context, userid string) (handled bool, e
 	if ckind == answerMatch {
 		ud := b.ud(ctx)
 		ud.d.targetCid = cCid
-		ud.d.targetChid = cChid
+		ud.d.targetUID = cUID
 		ud.d.replyTo = ""
 		ud.d.channelReply = true
 		if _, e := b.sendMsgTemplate(ctx, userid); e != nil {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -40,6 +40,11 @@ type Bot struct {
 	Texts *texts.Loader
 	Dyn   *dynset.Settings
 
+	// Tokens seals/opens the per-emission callback tokens that carry a user id in
+	// button callback_data (replacing the keyless, linkable EncodeChevaletID for
+	// NEW messages; see encoder/token.go). Keyed off BOT_TOKEN + TOKEN_KEYS.
+	Tokens *encoder.TokenCipher
+
 	users      *userStore
 	aiQueue    *aiQueue
 	admins     map[string]bool
@@ -116,12 +121,22 @@ func New(cfg *config.Config, database *db.DB, txt *texts.Loader) (*Bot, error) {
 		return nil, fmt.Errorf("bot: new bot: %w", err)
 	}
 
+	// Callback-token cipher, keyed off BOT_TOKEN (+ any TOKEN_KEYS). Fail closed:
+	// without a key the bot would emit unprotected/linkable tokens, so refuse to
+	// start rather than silently regress anonymity. (BOT_TOKEN is required, so this
+	// only trips on a misconfigured build.)
+	tokens := encoder.NewTokenCipher(cfg.BotToken, cfg.TokenKeys...)
+	if !tokens.Ready() {
+		return nil, fmt.Errorf("bot: callback-token cipher has no key (BOT_TOKEN missing?)")
+	}
+
 	b := &Bot{
 		TG:         tg,
 		DB:         database,
 		Cfg:        cfg,
 		Texts:      txt,
 		Dyn:        dynset.New("dynamic_settings.json", cfg.AIURL, cfg.AISessionID),
+		Tokens:     tokens,
 		users:      newUserStore(),
 		aiQueue:    newAIQueue(),
 		admins:     make(map[string]bool, len(cfg.Admins)),

--- a/internal/bot/callbacks.go
+++ b/internal/bot/callbacks.go
@@ -36,7 +36,7 @@ func answer(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error {
 	dbctx, cancel := b.bg()
 	defer cancel()
 
-	chid, ok, err := b.handleCIDOrChID(dbctx, msg, token)
+	targetUID, ok, err := b.resolveTargetUID(dbctx, msg, token)
 	if err != nil {
 		return err
 	}
@@ -44,11 +44,6 @@ func answer(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error {
 		return handlers.EndConversation()
 	}
 
-	plain, _ := encoder.DecodeChevaletID(chid)
-	targetUID, err := b.DB.GetUIDByChevaletID(dbctx, plain)
-	if err != nil {
-		return err
-	}
 	blocked, err := b.DB.IsBlocked(dbctx, targetUID, userid)
 	if err != nil {
 		return err
@@ -59,7 +54,7 @@ func answer(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error {
 	}
 
 	ud := b.ud(ctx)
-	ud.d.targetChid = chid
+	ud.d.targetUID = targetUID
 	ud.d.replyTo = targetMid
 
 	if _, err := msg.Reply(tg, txtAnswerPrompt, &gotgbot.SendMessageOpts{
@@ -88,17 +83,12 @@ func seen(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error {
 	dbctx, cancel := b.bg()
 	defer cancel()
 
-	chid, ok, err := b.handleCIDOrChID(dbctx, msg, token)
+	targetUID, ok, err := b.resolveTargetUID(dbctx, msg, token)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return handlers.EndConversation()
-	}
-	plain, _ := encoder.DecodeChevaletID(chid)
-	targetUID, err := b.DB.GetUIDByChevaletID(dbctx, plain)
-	if err != nil {
-		return err
 	}
 
 	blocked, err := b.DB.IsBlocked(dbctx, targetUID, userid)
@@ -170,17 +160,12 @@ func block(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error {
 	dbctx, cancel := b.bg()
 	defer cancel()
 
-	chid, ok, err := b.handleCIDOrChID(dbctx, msg, token)
+	targetUID, ok, err := b.resolveTargetUID(dbctx, msg, token)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return handlers.EndConversation()
-	}
-	plain, _ := encoder.DecodeChevaletID(chid)
-	targetUID, err := b.DB.GetUIDByChevaletID(dbctx, plain)
-	if err != nil {
-		return err
 	}
 
 	swap := func() {
@@ -237,17 +222,12 @@ func unblock(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error {
 	dbctx, cancel := b.bg()
 	defer cancel()
 
-	chid, ok, err := b.handleCIDOrChID(dbctx, msg, token)
+	targetUID, ok, err := b.resolveTargetUID(dbctx, msg, token)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return handlers.EndConversation()
-	}
-	plain, _ := encoder.DecodeChevaletID(chid)
-	targetUID, err := b.DB.GetUIDByChevaletID(dbctx, plain)
-	if err != nil {
-		return err
 	}
 
 	swap := func() {
@@ -305,7 +285,7 @@ func report(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, _ string) error {
 
 	dbctx, cancel := b.bg()
 	defer cancel()
-	_, ok, err := b.handleCIDOrChID(dbctx, msg, token)
+	_, ok, err := b.resolveTargetUID(dbctx, msg, token)
 	if err != nil {
 		return err
 	}
@@ -343,17 +323,12 @@ func reportConfirmYes(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) 
 
 	dbctx, cancel := b.bg()
 	defer cancel()
-	chid, ok, err := b.handleCIDOrChID(dbctx, msg, token)
+	targetUID, ok, err := b.resolveTargetUID(dbctx, msg, token)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return handlers.EndConversation()
-	}
-	plain, _ := encoder.DecodeChevaletID(chid)
-	targetUID, err := b.DB.GetUIDByChevaletID(dbctx, plain)
-	if err != nil {
-		return err
 	}
 
 	// delete the confirmation message
@@ -436,17 +411,12 @@ func deleteMsgClbk(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, _ string) error {
 
 	dbctx, cancel := b.bg()
 	defer cancel()
-	chid, ok, err := b.handleCIDOrChID(dbctx, msg, token)
+	targetUID, ok, err := b.resolveTargetUID(dbctx, msg, token)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return handlers.EndConversation()
-	}
-	plain, _ := encoder.DecodeChevaletID(chid)
-	targetUID, err := b.DB.GetUIDByChevaletID(dbctx, plain)
-	if err != nil {
-		return err
 	}
 	if targetUID == "" {
 		// Python asserted target_uid; a missing one is an unexpected state.

--- a/internal/bot/cidchid.go
+++ b/internal/bot/cidchid.go
@@ -2,33 +2,46 @@ package bot
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 
 	"github.com/aturzone/chevaletAnonBot/internal/encoder"
 )
 
-// handleCIDOrChID mirrors myhelpers.handle_cid_or_chid. The token comes from a
-// button's callback_data; on OLD messages (pre-chevaletid) it may be a plain
-// cid rather than an encoded chevaletid. The function returns the ENCODED
-// target chevaletid.
+// resolveTargetUID resolves a button's callback-data token to the target user's
+// uid, accepting three token generations (decode-both migration):
 //
-// ok=false is the Go equivalent of the Python END sentinel: the link is gone
-// (a "link changed" reply has already been sent), and the caller must stop.
-// A non-nil error is a genuine failure routed to the central error hook.
-func (b *Bot) handleCIDOrChID(ctx context.Context, msg *gotgbot.Message, token string) (encChid string, ok bool, err error) {
-	// It may be old and be a chevaletid: decodes cleanly AND resolves to a user.
+//  1. a NEW sealed token — b.Tokens.Open -> uid directly (current, unlinkable);
+//  2. an OLD encoded chevaletid — DecodeChevaletID -> chevaletid -> uid;
+//  3. a plain cid on very old (pre-chevaletid) buttons -> the link owner's uid.
+//
+// Trying the sealed cipher FIRST is safe: its 64-bit MAC makes a legacy token
+// opening as a new one a ~2^-64 event, and legacy/garbage inputs return false so
+// we fall through. (Ported/renamed from handle_cid_or_chid, which returned an
+// encoded chevaletid; callers now get the uid straight, dropping a decode + DB
+// lookup each.)
+//
+// ok=false with err==nil is the "link gone" END sentinel: a "link changed" reply
+// was already sent and the caller must stop. A non-nil error routes to onError.
+func (b *Bot) resolveTargetUID(ctx context.Context, msg *gotgbot.Message, token string) (uid string, ok bool, err error) {
+	// (1) NEW sealed token.
+	if u, good := b.Tokens.Open(token, nil); good {
+		return strconv.FormatInt(u, 10), true, nil
+	}
+
+	// (2) OLD encoded chevaletid: decodes cleanly AND resolves to a user.
 	if plain, decoded := encoder.DecodeChevaletID(token); decoded {
-		uid, derr := b.DB.GetUIDByChevaletID(ctx, plain)
+		u, derr := b.DB.GetUIDByChevaletID(ctx, plain)
 		if derr != nil {
 			return "", false, derr
 		}
-		if uid != "" {
-			return token, true, nil // it's a chevaletid; token is already encoded
+		if u != "" {
+			return u, true, nil
 		}
 	}
 
-	// Otherwise treat it as a cid.
+	// (3) Otherwise treat it as a cid (pre-chevaletid buttons carried the cid).
 	targetUID, err := b.DB.GetUIDByCID(ctx, token)
 	if err != nil {
 		return "", false, err
@@ -41,20 +54,16 @@ func (b *Bot) handleCIDOrChID(ctx context.Context, msg *gotgbot.Message, token s
 		return "", false, nil
 	}
 
-	// Ensure the target has a chevaletid (mint one if missing).
+	// Ensure the target still has a chevaletid (mint if missing) — preserves the
+	// original side effect for any downstream that resolves by chevaletid.
 	targetChid, err := b.DB.GetChevaletIDByUID(ctx, targetUID)
 	if err != nil {
 		return "", false, err
 	}
 	if targetChid == "" {
-		targetChid = encoder.GenerateChevaletID()
-		// Python's set_chevaletid always returned True, so its "failure" branch
-		// (an extra reply + ERROR_CHAT notice) was dead code; a real DB failure
-		// instead surfaced through psycopg2 to the central error handler. We do
-		// the same here: a SetChevaletID error propagates to onError.
-		if err := b.DB.SetChevaletID(ctx, targetUID, targetChid); err != nil {
+		if err := b.DB.SetChevaletID(ctx, targetUID, encoder.GenerateChevaletID()); err != nil {
 			return "", false, err
 		}
 	}
-	return encoder.EncodeChevaletID(targetChid), true, nil
+	return targetUID, true, nil
 }

--- a/internal/bot/markup.go
+++ b/internal/bot/markup.go
@@ -43,29 +43,29 @@ func cancelMarkup() *gotgbot.InlineKeyboardMarkup {
 
 // messageKeyboard builds the inline keyboard placed under every delivered
 // anonymous message, mirroring the first two rows of reply_markup_keyboard in
-// handler_templates.send_msg_template. senderEncChid is the already-encoded
-// chevaletid of the sender; mid is the sender's message id. When seen is true
+// handler_templates.send_msg_template. senderToken is the sealed, unlinkable
+// token carrying the sender's uid; mid is the sender's message id. When seen is true
 // the "mark as seen" button is inserted at the front of the first row, exactly
 // as the Python `reply_markup_keyboard[0].insert(0, ...)`.
 //
 // The caller appends the optional "sent with link N (cid)" row and the donation
 // row, matching the order the Python code assembles them.
-func messageKeyboard(senderEncChid string, mid int64, seen bool) [][]gotgbot.InlineKeyboardButton {
+func messageKeyboard(senderToken string, mid int64, seen bool) [][]gotgbot.InlineKeyboardButton {
 	midStr := strconv.FormatInt(mid, 10)
 	firstRow := []gotgbot.InlineKeyboardButton{
-		cb(msgBtnReply, "answer|"+senderEncChid+"|"+midStr),
+		cb(msgBtnReply, "answer|"+senderToken+"|"+midStr),
 	}
 	if seen {
 		firstRow = append([]gotgbot.InlineKeyboardButton{
-			cb(msgBtnSeen, "seen|"+senderEncChid+"|"+midStr),
+			cb(msgBtnSeen, "seen|"+senderToken+"|"+midStr),
 		}, firstRow...)
 	}
 	return [][]gotgbot.InlineKeyboardButton{
 		firstRow,
 		{
-			cb(msgBtnReport, "report|"+senderEncChid+"|"+midStr),
+			cb(msgBtnReport, "report|"+senderToken+"|"+midStr),
 			cb(" ", "no-callback"),
-			cb(msgBtnBlock, "block|"+senderEncChid),
+			cb(msgBtnBlock, "block|"+senderToken),
 		},
 	}
 }

--- a/internal/bot/media.go
+++ b/internal/bot/media.go
@@ -9,7 +9,6 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 
 	"github.com/aturzone/chevaletAnonBot/internal/config"
-	"github.com/aturzone/chevaletAnonBot/internal/encoder"
 )
 
 // handleMedia ports start.handle_media: the top-level handler for media-group
@@ -60,16 +59,11 @@ func handleMedia(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error
 	// add this media to the group
 	ud.d.groupMsgs = append(ud.d.groupMsgs, msg)
 
-	encodedTargetChid := ud.d.groupTargetChid
-	targetChid, _ := encoder.DecodeChevaletID(encodedTargetChid)
+	targetUID := ud.d.groupTargetUID
 
 	dbctx, cancel := b.bg()
 	defer cancel()
 
-	targetUID, err := b.DB.GetUIDByChevaletID(dbctx, targetChid)
-	if err != nil {
-		return err
-	}
 	targetID, err := strconv.ParseInt(targetUID, 10, 64)
 	if err != nil {
 		return err
@@ -173,7 +167,11 @@ func handleMedia(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error
 	}
 	tbd = dedupeOrdered(tbd)
 
-	deletionCallbackData := encodedTargetChid
+	deleteToken, err := b.Tokens.Seal(targetID, nil)
+	if err != nil {
+		return err
+	}
+	deletionCallbackData := deleteToken
 	for _, m := range tbd {
 		deletionCallbackData += "|" + m
 	}

--- a/internal/bot/sendmsg.go
+++ b/internal/bot/sendmsg.go
@@ -11,7 +11,6 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
 
 	"github.com/aturzone/chevaletAnonBot/internal/config"
-	"github.com/aturzone/chevaletAnonBot/internal/encoder"
 )
 
 // sendOutcome is the post-delete_notify_on_END result of send_msg_template:
@@ -83,7 +82,7 @@ func (b *Bot) sendMsgCore(ctx *ext.Context, userid string) (string, error) {
 		return delNone, nil
 	}
 
-	targetChidPlain, _ := encoder.DecodeChevaletID(ud.d.targetChid)
+	targetUID := ud.d.targetUID
 	targetCid := ud.d.targetCid
 	targetMid := ud.d.replyTo
 	wasChannelReply := ud.d.channelReply
@@ -96,11 +95,8 @@ func (b *Bot) sendMsgCore(ctx *ext.Context, userid string) (string, error) {
 	dbctx, cancel := b.bg()
 	defer cancel()
 
-	// target uid
-	targetUID, err := b.DB.GetUIDByChevaletID(dbctx, targetChidPlain)
-	if err != nil {
-		return "", err
-	}
+	// targetUID was resolved when the send flow was set up (start/answer, via
+	// resolveTargetUID); an empty one means the conversation state expired/was lost.
 	if targetUID == "" {
 		return delNone, b.replyHTML(ctx, txtSessionExpired, false)
 	}
@@ -118,13 +114,12 @@ func (b *Bot) sendMsgCore(ctx *ext.Context, userid string) (string, error) {
 
 	// if the user pressed "answer" but replied to a DIFFERENT message, cancel.
 	if targetMid != "" {
-		kind, mChid, mMid, aerr := b.isAnswer(ctx, false)
+		kind, mUID, mMid, aerr := b.isAnswer(ctx, false)
 		if aerr != nil {
 			return "", aerr
 		}
 		if kind == answerMatch {
-			mPlain, _ := encoder.DecodeChevaletID(mChid)
-			if !(mPlain == targetChidPlain && mMid == targetMid) {
+			if !(mUID == targetUID && mMid == targetMid) {
 				return delNone, b.replyHTML(ctx, txtSendingToAnother, false)
 			}
 		}
@@ -139,12 +134,18 @@ func (b *Bot) sendMsgCore(ctx *ext.Context, userid string) (string, error) {
 		return delNone, b.replyText(ctx, txtBlockedYou)
 	}
 
-	// sender's encoded chevaletid (so the markup never leaks the uid/raw chid)
-	senderChid, err := b.DB.GetChevaletIDByUID(dbctx, userid)
+	// Seal the SENDER's uid into an opaque, unlinkable token for the message's
+	// buttons — replaces the keyless EncodeChevaletID, which was reversible by any
+	// recipient once the source is public (S-0002). Two sends -> two nonces -> two
+	// unlinkable tokens; only the bot's key opens them.
+	senderID, perr := strconv.ParseInt(userid, 10, 64)
+	if perr != nil {
+		return "", perr
+	}
+	senderToken, err := b.Tokens.Seal(senderID, nil)
 	if err != nil {
 		return "", err
 	}
-	senderEncChid := encoder.EncodeChevaletID(senderChid)
 
 	// reply / quote calculation (strings, like the Python original; converted to
 	// int64 at the gotgbot boundary in copyToTarget).
@@ -186,7 +187,7 @@ func (b *Bot) sendMsgCore(ctx *ext.Context, userid string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	keyboard := messageKeyboard(senderEncChid, msg.MessageId, seen)
+	keyboard := messageKeyboard(senderToken, msg.MessageId, seen)
 
 	targetCids, err := b.DB.GetCIDs(dbctx, targetUID)
 	if err != nil {
@@ -232,8 +233,8 @@ func (b *Bot) sendMsgCore(ctx *ext.Context, userid string) (string, error) {
 		ud.d.mediaGroupID = mediaGroupID
 		ud.d.groupMsgs = []*gotgbot.Message{msg}
 		ud.d.groupExpiration = nowSeconds() + config.ExpireAfter
-		// target_chid / reply_to / channel_reply were reset by ud.clear() above.
-		ud.d.groupTargetChid = encoder.EncodeChevaletID(targetChidPlain)
+		// target_uid / reply_to / channel_reply were reset by ud.clear() above.
+		ud.d.groupTargetUID = targetUID
 		ud.d.groupWasChannelReply = wasChannelReply
 		ud.d.groupNotifyMsg = notifyMsg
 		ud.d.groupReplyMarkup = &replyMarkup
@@ -272,14 +273,19 @@ func (b *Bot) sendMsgCore(ctx *ext.Context, userid string) (string, error) {
 		}) // errors ignored, like the Python try/except pass
 	}
 
-	// "sent" + the deletion warning. The callback data carries a fresh encoding
-	// of the target chid plus the copied (and notify) message ids; when notify is
-	// nil the Python f-string produced the literal "None", which we reproduce.
+	// "sent" + the deletion warning. The callback data carries a fresh sealed token
+	// of the TARGET uid (so the sender can delete their message from the target's
+	// chat) plus the copied (and notify) message ids; when notify is nil the Python
+	// f-string produced the literal "None", which we reproduce.
 	notifyPart := "None"
 	if notifyMsg != nil {
 		notifyPart = strconv.FormatInt(notifyMsg.MessageId, 10)
 	}
-	deletionCallbackData := encoder.EncodeChevaletID(targetChidPlain) + "|" +
+	deleteToken, err := b.Tokens.Seal(targetID, nil)
+	if err != nil {
+		return "", err
+	}
+	deletionCallbackData := deleteToken + "|" +
 		strconv.FormatInt(copiedID, 10) + "|" + notifyPart
 	if _, err := b.warningHandle(ctx, wasChannelReply, targetUID, userid, deletionCallbackData); err != nil {
 		return "", err
@@ -441,12 +447,12 @@ func (b *Bot) warningHandle(ctx *ext.Context, wasChannelReply bool, targetUID, u
 }
 
 // packDeleteButtons greedily packs message ids into "delete" buttons whose
-// callback_data ("delete|<encChid>|<mid>|<mid>…") stays within Telegram's 64-byte
+// callback_data ("delete|<token>|<mid>|<mid>…") stays within Telegram's 64-byte
 // limit, then groups the buttons two-per-row. Each id appears exactly once across
 // the buttons, in order. Mirrors handler_templates._warning_handle's packing loop
 // (the layout deleteMsgClbk re-parses), extracted so it can be unit-tested.
-func packDeleteButtons(encChid string, mids []string) [][]gotgbot.InlineKeyboardButton {
-	kbTemplate := func() []string { return []string{"delete", encChid} }
+func packDeleteButtons(token string, mids []string) [][]gotgbot.InlineKeyboardButton {
+	kbTemplate := func() []string { return []string{"delete", token} }
 	isValid := func(rm []string) bool { return len(strings.Join(rm, "|")) <= 64 }
 
 	var buttons []gotgbot.InlineKeyboardButton

--- a/internal/bot/sendmsg_test.go
+++ b/internal/bot/sendmsg_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // midsFromRows flattens the delete buttons back to their packed message ids
-// (everything after "delete|<encChid>" in each button's callback_data).
-func midsFromRows(t *testing.T, rows [][]gotgbot.InlineKeyboardButton, encChid string) []string {
+// (everything after "delete|<token>" in each button's callback_data).
+func midsFromRows(t *testing.T, rows [][]gotgbot.InlineKeyboardButton, token string) []string {
 	t.Helper()
 	var got []string
 	for _, r := range rows {
@@ -23,8 +23,8 @@ func midsFromRows(t *testing.T, rows [][]gotgbot.InlineKeyboardButton, encChid s
 				t.Errorf("button callback_data %q is %d bytes (>64)", btn.CallbackData, len(btn.CallbackData))
 			}
 			fields := strings.Split(btn.CallbackData, "|")
-			if len(fields) < 3 || fields[0] != "delete" || fields[1] != encChid {
-				t.Fatalf("malformed delete data %q (want delete|%s|...)", btn.CallbackData, encChid)
+			if len(fields) < 3 || fields[0] != "delete" || fields[1] != token {
+				t.Fatalf("malformed delete data %q (want delete|%s|...)", btn.CallbackData, token)
 			}
 			got = append(got, fields[2:]...)
 		}
@@ -43,14 +43,14 @@ func TestPackDeleteButtons(t *testing.T) {
 	}
 
 	// overflow: a long chid so each button holds exactly one mid (1 fits, 2 overflow).
-	encChid := strings.Repeat("A", 52) // delete|<52>|XX = 62 bytes; +|XX = 67 > 64
+	token := strings.Repeat("A", 52) // delete|<52>|XX = 62 bytes; +|XX = 67 > 64
 	mids := []string{"10", "20", "30", "40", "50"}
-	rows = packDeleteButtons(encChid, mids)
+	rows = packDeleteButtons(token, mids)
 	// 5 single-mid buttons -> rows of 2,2,1.
 	if len(rows) != 3 || len(rows[0]) != 2 || len(rows[1]) != 2 || len(rows[2]) != 1 {
 		t.Fatalf("overflow row shape = %v; want [2 2 1]", rowSizes(rows))
 	}
-	got := midsFromRows(t, rows, encChid)
+	got := midsFromRows(t, rows, token)
 	if strings.Join(got, ",") != strings.Join(mids, ",") {
 		t.Errorf("packed mids = %v; want %v (each once, in order)", got, mids)
 	}

--- a/internal/bot/start.go
+++ b/internal/bot/start.go
@@ -65,13 +65,17 @@ func (b *Bot) startUnblock(tg *gotgbot.Bot, ctx *ext.Context, userid, arg string
 		if _, err := b.DB.RemoveBlock(dbctx, userid, targetUID); err != nil {
 			return err
 		}
-		chid, err := b.DB.GetChevaletIDByUID(dbctx, targetUID)
+		tid, err := strconv.ParseInt(targetUID, 10, 64)
+		if err != nil {
+			return err
+		}
+		token, err := b.Tokens.Seal(tid, nil)
 		if err != nil {
 			return err
 		}
 		text := "این یوزر برات آنبلاک شد:\n" + b.getUsername(targetUID) + " | " + hrefUser(targetUID, "")
 		markup := gotgbot.InlineKeyboardMarkup{InlineKeyboard: [][]gotgbot.InlineKeyboardButton{{
-			cb(btnBlockAgain, "block|"+encoder.EncodeChevaletID(chid)),
+			cb(btnBlockAgain, "block|"+token),
 		}}}
 		if _, err := msg.Reply(tg, text, &gotgbot.SendMessageOpts{ParseMode: "HTML", ReplyMarkup: markup}); err != nil {
 			return err
@@ -114,7 +118,6 @@ func (b *Bot) startConnect(tg *gotgbot.Bot, ctx *ext.Context, userid, targetCid 
 			return err
 		}
 	}
-	encChid := encoder.EncodeChevaletID(targetChid)
 
 	blocked, err := b.DB.IsBlocked(dbctx, targetUID, userid)
 	if err != nil {
@@ -145,7 +148,7 @@ func (b *Bot) startConnect(tg *gotgbot.Bot, ctx *ext.Context, userid, targetCid 
 
 	ud := b.ud(ctx)
 	ud.d.targetCid = targetCid
-	ud.d.targetChid = encChid // already encoded
+	ud.d.targetUID = targetUID
 	ud.d.replyTo = ""
 
 	selfPrefix := ""

--- a/internal/bot/userdata.go
+++ b/internal/bot/userdata.go
@@ -67,7 +67,7 @@ func (u *userData) allowSend() bool {
 // Empty string / nil / false / zero stand in for Python's missing-key / None.
 type convData struct {
 	// single-message send flow (set by start_cmd / answer, read by send_msg_template)
-	targetChid   string // "target_chid": already-encoded chevaletid
+	targetUID    string // "target_uid": the resolved target user id (server-side only)
 	targetCid    string // "target_cid": cid, or "" when not a /start send
 	replyTo      string // "reply_to": target message id, or "" when not an answer
 	channelReply bool   // "channel_reply": True only for reply-to-channel sends
@@ -76,7 +76,7 @@ type convData struct {
 	mediaGroupID         string                        // "media_group_id"
 	groupMsgs            []*gotgbot.Message            // "group_msgs"
 	groupExpiration      float64                       // "group_expiration": unix seconds, 0 = unset
-	groupTargetChid      string                        // "group_target_chid": encoded
+	groupTargetUID       string                        // "group_target_uid": resolved target user id
 	groupWasChannelReply bool                          // "group_was_channel_reply"
 	groupNotifyMsg       *gotgbot.Message              // "group_notify_msg"
 	groupReplyMarkup     *gotgbot.InlineKeyboardMarkup // "group_reply_markup"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,12 @@ type Config struct {
 	AIEnabled   bool // AI_ENABLED — the GM-group AI auto-reply is OFF unless "true"
 
 	DonationLink string
+
+	// TokenKeys are OPTIONAL extra secrets (TOKEN_KEYS, comma-separated) kept in
+	// the callback-token keyring for rotation: the current key is derived from
+	// BOT_TOKEN, and these older secrets (e.g. a previous BOT_TOKEN) let buttons
+	// minted before a token change still resolve. Empty by default.
+	TokenKeys []string
 }
 
 // Load reads configuration from the process environment. If a .env file exists
@@ -218,6 +224,16 @@ func Load() (*Config, error) {
 	}
 
 	c.DonationLink = req("DONATION_LINK")
+
+	// Optional callback-token rotation keyring (see TokenKeys). Trimmed, blanks
+	// dropped, so "a, ,b" -> ["a","b"].
+	if v := opt("TOKEN_KEYS", ""); v != "" {
+		for _, k := range strings.Split(v, ",") {
+			if k = strings.TrimSpace(k); k != "" {
+				c.TokenKeys = append(c.TokenKeys, k)
+			}
+		}
+	}
 
 	if len(missing) > 0 {
 		errs = append(errs, "missing required environment variables: "+strings.Join(missing, ", "))

--- a/internal/encoder/token.go
+++ b/internal/encoder/token.go
@@ -1,0 +1,178 @@
+package encoder
+
+// token.go replaces the KEYLESS chevaletid obfuscation (EncodeChevaletID) for
+// NEW callback_data with a server-SECRET-keyed, per-emission-randomized token.
+//
+// WHY: EncodeChevaletID is reversible by anyone (it carries its own key), so once
+// the source is public a recipient can read a message's inline-button
+// callback_data via an MTProto userbot, decode the sender's STABLE chevaletid,
+// and link every message from that sender without consent (S-0002). The Telegram
+// uid never leaves the DB, but linkability alone breaks the "can't tell one
+// person from many" guarantee.
+//
+// FIX (Fable "Option C", uid-sealed): the token seals the user id (7 bytes, not
+// the long chevaletid string, so it fits Telegram's 64-byte callback_data limit)
+// under a key derived from a server secret, with a fresh random nonce each time:
+//
+//	token = base64url( nonce(8) || ct(7 = uid XOR keystream) || tag(8 = HMAC) )
+//	keystream = HMAC(key, "enc" || nonce)[:7]      (one-time pad for the uid)
+//	tag       = HMAC(key, "mac" || nonce || ct || aad)[:8]   (encrypt-then-MAC)
+//
+// Only a holder of the key can Open it; two tokens for the same uid are
+// computationally unlinkable (fresh nonce => semantic security). Truncated-HMAC
+// authentication (64-bit) makes forgery require ~2^64 ONLINE callbacks. aad binds
+// extra framing (e.g. a message id) with zero token bytes when a caller wants it;
+// v1 passes nil.
+//
+// The legacy EncodeChevaletID/DecodeChevaletID stay UNTOUCHED (golden-locked) as
+// the decode-both fallback so buttons on already-delivered messages keep working.
+import (
+	"crypto/hmac"
+	crand "crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+)
+
+const (
+	tokenNonceLen = 8 // 64-bit random nonce; birthday collision ~2^32 emissions
+	tokenUIDLen   = 7 // 56-bit, covers Telegram's documented <2^52 id range
+	tokenTagLen   = 8 // 64-bit truncated HMAC; online forgery ~2^64
+	tokenRawLen   = tokenNonceLen + tokenUIDLen + tokenTagLen
+)
+
+// tokenKeyLabel domain-separates the callback-token key derivation from any other
+// use of the same server secret. "v1" allows a future scheme bump.
+const tokenKeyLabel = "chevalet:callback-token:v1"
+
+// errNoRand is returned by Seal if the OS CSPRNG fails — the caller must fail the
+// send rather than emit a token with a predictable nonce (which would silently
+// destroy unlinkability).
+var errNoRand = errors.New("encoder: crypto/rand unavailable")
+
+// TokenCipher seals/opens callback tokens under a keyring. keys[0] is the current
+// key (used to Seal); every key is tried on Open so a key can be rotated by
+// PREPENDING a new one while keeping the old — old buttons keep resolving. Keys
+// are never removed in normal operation (32 bytes each), so nothing breaks.
+type TokenCipher struct {
+	keys [][]byte
+}
+
+// NewTokenCipher derives the current key from primary (the bot's BOT_TOKEN, so
+// there is no separate key to manage or lose — it lives exactly as long as the
+// bot) and prepends any non-empty extra secrets as older keyring entries for
+// rotation. A nil/empty primary yields a cipher whose Seal fails closed.
+func NewTokenCipher(primary string, extra ...string) *TokenCipher {
+	tc := &TokenCipher{}
+	if primary != "" {
+		tc.keys = append(tc.keys, deriveTokenKey(primary))
+	}
+	for _, s := range extra {
+		if s != "" {
+			tc.keys = append(tc.keys, deriveTokenKey(s))
+		}
+	}
+	return tc
+}
+
+// Ready reports whether the cipher has at least one key (so callers can fail
+// closed at startup rather than emit unprotected tokens).
+func (tc *TokenCipher) Ready() bool { return tc != nil && len(tc.keys) > 0 }
+
+// deriveTokenKey turns a high-entropy secret into a 32-byte key via one HMAC
+// (a single-block HKDF-Expand); sound because the secret is already high-entropy.
+func deriveTokenKey(secret string) []byte {
+	m := hmac.New(sha256.New, []byte(secret))
+	m.Write([]byte(tokenKeyLabel))
+	return m.Sum(nil)
+}
+
+// prf = HMAC-SHA256(key, domain || data), domain-separating the keystream ("enc")
+// from the tag ("mac").
+func prf(key []byte, domain string, parts ...[]byte) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write([]byte(domain))
+	for _, p := range parts {
+		m.Write(p)
+	}
+	return m.Sum(nil)
+}
+
+// Seal encrypts uid into an opaque, unlinkable token. aad (may be nil) is
+// authenticated but not transmitted.
+func (tc *TokenCipher) Seal(uid int64, aad []byte) (string, error) {
+	if !tc.Ready() {
+		return "", errors.New("encoder: token cipher has no key")
+	}
+	key := tc.keys[0]
+
+	var nonce [tokenNonceLen]byte
+	if _, err := crand.Read(nonce[:]); err != nil {
+		return "", errNoRand
+	}
+
+	var uidb [tokenUIDLen]byte
+	putUID(uidb[:], uid)
+
+	ks := prf(key, "enc", nonce[:])[:tokenUIDLen]
+	ct := make([]byte, tokenUIDLen)
+	for i := range ct {
+		ct[i] = uidb[i] ^ ks[i]
+	}
+	tag := prf(key, "mac", nonce[:], ct, aad)[:tokenTagLen]
+
+	raw := make([]byte, 0, tokenRawLen)
+	raw = append(raw, nonce[:]...)
+	raw = append(raw, ct...)
+	raw = append(raw, tag...)
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+// Open reverses Seal: returns (uid, true) iff token is a well-formed, key-valid,
+// aad-matching token under some keyring key; (0, false) otherwise (including any
+// legacy/garbage input — the caller then tries the legacy decoder).
+func (tc *TokenCipher) Open(token string, aad []byte) (int64, bool) {
+	if !tc.Ready() {
+		return 0, false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(raw) != tokenRawLen {
+		return 0, false
+	}
+	nonce := raw[:tokenNonceLen]
+	ct := raw[tokenNonceLen : tokenNonceLen+tokenUIDLen]
+	tag := raw[tokenNonceLen+tokenUIDLen:]
+
+	for _, key := range tc.keys {
+		want := prf(key, "mac", nonce, ct, aad)[:tokenTagLen]
+		if subtle.ConstantTimeCompare(tag, want) == 1 {
+			ks := prf(key, "enc", nonce)[:tokenUIDLen]
+			var uidb [tokenUIDLen]byte
+			for i := range uidb {
+				uidb[i] = ct[i] ^ ks[i]
+			}
+			return getUID(uidb[:]), true
+		}
+	}
+	return 0, false
+}
+
+// putUID writes uid as tokenUIDLen big-endian bytes (uid is a positive Telegram
+// id < 2^52, so the top byte of an int64 is never significant here).
+func putUID(b []byte, uid int64) {
+	u := uint64(uid)
+	for i := tokenUIDLen - 1; i >= 0; i-- {
+		b[i] = byte(u)
+		u >>= 8
+	}
+}
+
+// getUID reverses putUID.
+func getUID(b []byte) int64 {
+	var u uint64
+	for _, c := range b {
+		u = u<<8 | uint64(c)
+	}
+	return int64(u)
+}

--- a/internal/encoder/token_test.go
+++ b/internal/encoder/token_test.go
@@ -1,0 +1,147 @@
+package encoder
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const testBotToken = "7133040550:AA-fake-token-for-tests-only_xyz"
+
+func TestTokenRoundTrip(t *testing.T) {
+	tc := NewTokenCipher(testBotToken)
+	for _, uid := range []int64{1, 84581926, 6857450344, 999999999999, 1<<52 - 1, 0} {
+		tok, err := tc.Seal(uid, nil)
+		if err != nil {
+			t.Fatalf("Seal(%d): %v", uid, err)
+		}
+		got, ok := tc.Open(tok, nil)
+		if !ok || got != uid {
+			t.Errorf("Open(Seal(%d)) = (%d,%v); want (%d,true)", uid, got, ok, uid)
+		}
+	}
+}
+
+func TestTokenUnlinkable(t *testing.T) {
+	tc := NewTokenCipher(testBotToken)
+	uid := int64(6857450344)
+	t1, _ := tc.Seal(uid, nil)
+	t2, _ := tc.Seal(uid, nil)
+	// Same sender, two messages -> the tokens in the buttons MUST differ (this is
+	// the whole point: a recipient can't link them without the key).
+	if t1 == t2 {
+		t.Fatal("two Seals of the same uid produced identical tokens (linkable!)")
+	}
+	// ...yet both open to the same uid for the bot.
+	if u1, _ := tc.Open(t1, nil); u1 != uid {
+		t.Errorf("t1 opened to %d; want %d", u1, uid)
+	}
+	// The plaintext uid must not appear verbatim in the token.
+	if strings.Contains(t1, strconv.FormatInt(uid, 10)) {
+		t.Errorf("token %q leaks the decimal uid", t1)
+	}
+}
+
+func TestTokenTamperRejected(t *testing.T) {
+	tc := NewTokenCipher(testBotToken)
+	tok, _ := tc.Seal(6857450344, nil)
+	b := []byte(tok)
+	for _, i := range []int{0, len(b) / 2, len(b) - 1} {
+		orig := b[i]
+		b[i] = flipChar(orig)
+		if _, ok := tc.Open(string(b), nil); ok {
+			t.Errorf("tampered token (byte %d) opened; want reject", i)
+		}
+		b[i] = orig
+	}
+}
+
+func TestTokenAAD(t *testing.T) {
+	tc := NewTokenCipher(testBotToken)
+	uid := int64(84581926)
+	tok, _ := tc.Seal(uid, []byte("624600")) // e.g. bound to a message id
+	if got, ok := tc.Open(tok, []byte("624600")); !ok || got != uid {
+		t.Errorf("Open with matching aad = (%d,%v); want (%d,true)", got, ok, uid)
+	}
+	if _, ok := tc.Open(tok, []byte("624601")); ok {
+		t.Error("Open with a DIFFERENT aad succeeded; aad binding is broken")
+	}
+	if _, ok := tc.Open(tok, nil); ok {
+		t.Error("Open with nil aad succeeded for an aad-sealed token")
+	}
+}
+
+func TestTokenWrongKey(t *testing.T) {
+	a := NewTokenCipher(testBotToken)
+	b := NewTokenCipher("a-completely-different-secret")
+	tok, _ := a.Seal(6857450344, nil)
+	if _, ok := b.Open(tok, nil); ok {
+		t.Error("a token sealed under key A opened under key B")
+	}
+}
+
+func TestTokenKeyring(t *testing.T) {
+	old := NewTokenCipher("old-secret")
+	tokOld, _ := old.Seal(6857450344, nil)
+
+	// After rotation the current key is "new-secret" but "old-secret" stays in the
+	// ring, so buttons minted before rotation still resolve.
+	rotated := NewTokenCipher("new-secret", "old-secret")
+	if got, ok := rotated.Open(tokOld, nil); !ok || got != 6857450344 {
+		t.Errorf("rotated ring failed to open an old-key token: (%d,%v)", got, ok)
+	}
+	// New seals use the current (first) key, which the OLD cipher can't open.
+	tokNew, _ := rotated.Seal(6857450344, nil)
+	if _, ok := old.Open(tokNew, nil); ok {
+		t.Error("old cipher opened a token sealed with the new current key")
+	}
+}
+
+func TestTokenBudget(t *testing.T) {
+	tc := NewTokenCipher(testBotToken)
+	tok, _ := tc.Seal(1<<52-1, nil) // max-length uid
+	if len(tok) != 31 {
+		t.Errorf("token length = %d; expected 31 chars", len(tok))
+	}
+	// Worst-case framing: the longest verb + a 10-digit message id must fit 64.
+	worst := "report_yes|" + tok + "|" + "9999999999"
+	if len(worst) > 64 {
+		t.Errorf("worst-case callback_data %q is %d bytes (>64)", worst, len(worst))
+	}
+}
+
+func TestTokenRejectsLegacyAndGarbage(t *testing.T) {
+	tc := NewTokenCipher(testBotToken)
+	// A legacy EncodeChevaletID output must NOT open as a new token (so the caller
+	// falls through to the legacy decoder) — and must never panic.
+	legacy := EncodeChevaletID(GenerateChevaletID())
+	if _, ok := tc.Open(legacy, nil); ok {
+		t.Error("a legacy token opened as a new token (decode-both ambiguity)")
+	}
+	for _, junk := range []string{"", "!!!not base64!!!", "short", strings.Repeat("A", 200)} {
+		if _, ok := tc.Open(junk, nil); ok {
+			t.Errorf("garbage %q opened as a token", junk)
+		}
+	}
+}
+
+func TestTokenNotReady(t *testing.T) {
+	tc := NewTokenCipher("") // no key
+	if tc.Ready() {
+		t.Fatal("empty-secret cipher reports Ready")
+	}
+	if _, err := tc.Seal(1, nil); err == nil {
+		t.Error("Seal on a keyless cipher must fail closed")
+	}
+	if _, ok := tc.Open("anything", nil); ok {
+		t.Error("Open on a keyless cipher must return false")
+	}
+}
+
+// flipChar returns a different base64url char than c.
+func flipChar(c byte) byte {
+	if c == 'A' {
+		return 'B'
+	}
+	return 'A'
+}


### PR DESCRIPTION
…bility

The sender's STABLE chevaletid was placed in button callback_data via keyless, self-decoding obfuscation (EncodeChevaletID), so once the source is public a recipient (MTProto userbot) could decode it and LINK every message from one sender without consent. Replace it, for NEW callback_data, with a server-secret-keyed, per-emission-randomized token:

  token = base64url(nonce8 || uid XOR keystream(7) || HMAC-tag(8))   # 31 chars

keyed off BOT_TOKEN (HMAC-as-KDF) so there's no separate key to manage/lose and none ever ships in the open-source repo. Fresh nonce per emission => unlinkable; only the bot's key opens it. Encrypt-then-MAC, domain-separated HMAC, constant-time verify, crypto/rand fail-closed.

- encoder/token.go: TokenCipher.Seal/Open + a TOKEN_KEYS rotation keyring; legacy Encode/DecodeChevaletID kept UNTOUCHED (golden-locked) as the decode-both fallback so buttons on already-delivered messages keep working.
- bot: all 4 callback_data emit sites Seal(uid); resolve unified in resolveTargetUID (Open -> legacy chevaletid -> cid) across the 7 callbacks + isAnswer; internal conversation state moved from encoded-chevaletid to plain uid (never reaches callback_data). bot.go fails closed without a key.
- Fable-reviewed GO (no blocker/major): crypto sound, unlinkability achieved, decode-both correct, 64-byte budget safe, no regression.
- Scope: fixes S-0002 (linkability). S-0001 (mid-BOLA) intentionally unchanged.

## Summary

<!-- What does this PR do and why? -->

## Type of change

- [ ] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `maint` — refactor / chore / dependency bump
- [ ] `docs` — documentation
- [ ] `ci` — build / CI

## Checklist

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `gofmt -l .` prints nothing
- [ ] `go test -race ./...` passes
- [ ] I did **not** change the `internal/encoder` cipher output (frozen contract)
- [ ] User-visible behavior changes are described above

## Notes for reviewers

<!-- Anything reviewers should pay special attention to. -->
