### PR TITLE
fix: dedupe nightly backup notification via marker file, not docker logs

### DIFF
--- a/deploy/go/README.md
+++ b/deploy/go/README.md
@@ -52,6 +52,25 @@ proxy, so a working `PROXY` is required.
 
 `.env` is git-ignored — the token never lands in the repo.
 
+## Production backup crons
+
+The production deploy (`docker-compose.cutover.yml`, `/opt/chevalet-go-staging`
+on the server) runs two host-side cron jobs alongside the bot container:
+
+```
+0 * * * *  /opt/chevalet-go-staging/deploy/go/backup.sh                      # hourly DB dump
+40 20 * * * /opt/chevalet-go-staging/deploy/go/nightly-backup-backstop.sh    # re-send if the bot's own nightly DM failed
+```
+
+`backup.sh` dumps `telegram-bot-db` hourly into the host `backups/` dir, which
+is bind-mounted into the container at `/app/backups`. Once a night at
+`BACKUP_TIME` (`internal/bot/background.go`'s `backupLoop`) the bot itself DMs
+the newest file to `BACKUP_ADMIN_ID` and touches `backups/.nightly-backup-sent`.
+`nightly-backup-backstop.sh` runs a few minutes after `BACKUP_TIME` and
+re-sends the same file only if that marker is missing or stale — see the
+script's header comment for why it checks a marker file rather than `docker
+logs` (the latter caused nightly duplicate sends in production).
+
 ## Notes
 
 - This stack is for staging/verification only; the production cutover (Go bot

--- a/deploy/go/nightly-backup-backstop.sh
+++ b/deploy/go/nightly-backup-backstop.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Nightly DB-backup backstop for the Go bot.
+#
+# The bot itself DMs the newest backup to BACKUP_ADMIN_ID once a night at
+# BACKUP_TIME (see internal/bot/background.go: backupLoop/sendLatestBackupTo).
+# This script is a safety net that runs a few minutes later and re-sends the
+# same file ONLY if that in-process job didn't already succeed tonight —
+# otherwise the admin gets the backup twice.
+#
+# Dedup: sendLatestBackupTo (re)touches backups/.nightly-backup-sent on every
+# successful send. This script skips if that marker is fresh (< 6h old).
+#
+# A prior version of this script deduped by grepping `docker logs --since`,
+# which turned out to return zero lines regardless of the requested window in
+# this environment — the dedup silently never matched, so the backstop fired
+# (and double-sent) every single night. See internal/bot/background.go's
+# nightlySentMarker doc comment for the full story. Do not revert to that
+# approach without first confirming `docker logs --since` is reliable here.
+#
+# Cron (a few minutes after BACKUP_TIME in the .env.prod timezone, Asia/Tehran):
+#   40 20 * * * /opt/chevalet-go-staging/deploy/go/nightly-backup-backstop.sh >> /opt/chevalet-go-staging/logs/backup-backstop.log 2>&1
+#
+# Usage: nightly-backup-backstop.sh [force]
+#   force - skip the dedup check and send unconditionally (manual testing).
+set -uo pipefail
+
+ENVP=/opt/chevalet-go-staging/deploy/go/.env.prod
+BDIR=/opt/chevalet-go-staging/backups
+LOG=/opt/chevalet-go-staging/logs/backup-backstop.log
+MARKER="$BDIR/.nightly-backup-sent"
+DEDUP_WINDOW_SECONDS=$((6 * 3600))
+
+mkdir -p "$(dirname "$LOG")"
+ts(){ date -u +%FT%TZ; }
+
+BOT_TOKEN=$(grep -E '^BOT_TOKEN=' "$ENVP" | cut -d= -f2- | tr -d '\r')
+ADMIN=$(grep -E '^BACKUP_ADMIN_ID=' "$ENVP" | cut -d= -f2- | tr -d '\r')
+FORCE="${1:-}"
+
+if [ "$FORCE" != "force" ] && [ -f "$MARKER" ]; then
+  MARKER_MTIME=$(stat -c %Y "$MARKER" 2>/dev/null || stat -f %m "$MARKER" 2>/dev/null || echo 0)
+  AGE=$(( $(date +%s) - MARKER_MTIME ))
+  if [ "$AGE" -lt "$DEDUP_WINDOW_SECONDS" ]; then
+    echo "$(ts) skip: bot already sent tonight (marker ${AGE}s old)" >> "$LOG"
+    exit 0
+  fi
+fi
+
+NEWEST=$(ls -1t "$BDIR"/backup_*.sql.gz 2>/dev/null | head -1)
+[ -z "$NEWEST" ] && { echo "$(ts) ERROR no backup file" >> "$LOG"; echo NO_FILE; exit 1; }
+
+RESP=$(curl -sS --max-time 150 -F chat_id="$ADMIN" -F document=@"$NEWEST" -F caption="DB backup (backstop): $(basename "$NEWEST")" "https://api.telegram.org/bot${BOT_TOKEN}/sendDocument")
+if echo "$RESP" | grep -q '"ok":true'; then
+  echo "$(ts) sent $(basename "$NEWEST")" >> "$LOG"; echo SENT_OK
+else
+  echo "$(ts) FAILED: $(echo "$RESP" | tr -d '\n' | head -c 180)" >> "$LOG"; echo SENT_FAIL
+fi

--- a/internal/bot/background.go
+++ b/internal/bot/background.go
@@ -231,6 +231,23 @@ func (b *Bot) backupLoop(ctx context.Context, hm [2]int, adminID int64) {
 // latestBackupFile). An older hourly backup always exists, so this never starves.
 const backupMinAge = 3 * time.Minute
 
+// nightlySentMarker is (re)written to the backups dir after a successful
+// nightly send. deploy/go/nightly-backup-backstop.sh — a host-side cron that
+// re-sends the backup if this job silently failed — checks this file's mtime
+// instead of grepping `docker logs`: `docker logs --since <duration>` proved
+// unreliable in production (it returned zero lines regardless of the window,
+// even moments after this job logged successfully), which made the backstop
+// fire every night and double-send. A plain mtime check has no such failure
+// mode and needs no log driver cooperation.
+const nightlySentMarker = ".nightly-backup-sent"
+
+// touchNightlySentMarker (re)creates the marker file in dir, refreshing its
+// mtime to now. Best-effort: a write failure is the caller's to log, not fatal
+// (the Telegram send already succeeded either way).
+func touchNightlySentMarker(dir string) error {
+	return os.WriteFile(filepath.Join(dir, nightlySentMarker), nil, 0o600)
+}
+
 // sendLatestBackupTo sends the newest settled backups/ file to a SINGLE chat id
 // (the nightly admin DM). Best-effort — every failure is logged, never fatal —
 // and it targets exactly one chat: it never iterates users / never broadcasts.
@@ -262,6 +279,9 @@ func (b *Bot) sendLatestBackupTo(chatID int64) {
 		return
 	}
 	slog.Info("nightly backup sent", "to", chatID, "file", latest)
+	if err := touchNightlySentMarker("backups"); err != nil {
+		slog.Warn("nightly backup: marker write failed", "err", err)
+	}
 }
 
 // notifyBackupFail best-effort tells the admin chat the nightly backup didn't go

--- a/internal/bot/backup_test.go
+++ b/internal/bot/backup_test.go
@@ -63,3 +63,38 @@ func TestLatestBackupFile(t *testing.T) {
 		t.Error("missing dir: want an error, got nil")
 	}
 }
+
+// TestTouchNightlySentMarker locks the marker file's name and its
+// create-or-refresh behavior: deploy/go/nightly-backup-backstop.sh dedupes by
+// checking this file's mtime, so a stale marker must never linger unrefreshed
+// and a repeat call must always bump the mtime forward (not just "create once").
+func TestTouchNightlySentMarker(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, nightlySentMarker)
+
+	if err := touchNightlySentMarker(dir); err != nil {
+		t.Fatalf("first touch: %v", err)
+	}
+	info, err := os.Stat(marker)
+	if err != nil {
+		t.Fatalf("marker not created: %v", err)
+	}
+	firstMtime := info.ModTime()
+
+	// Back-date the marker (as if it were written last night), then touch again:
+	// the mtime must move forward to "now", not stay pinned at the old value.
+	old := firstMtime.Add(-24 * time.Hour)
+	if err := os.Chtimes(marker, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := touchNightlySentMarker(dir); err != nil {
+		t.Fatalf("second touch: %v", err)
+	}
+	info, err = os.Stat(marker)
+	if err != nil {
+		t.Fatalf("marker missing after second touch: %v", err)
+	}
+	if !info.ModTime().After(old) {
+		t.Errorf("second touch did not refresh mtime: got %v, want after %v", info.ModTime(), old)
+	}
+}


### PR DESCRIPTION
Closes #5

**Bug**: the admin gets the nightly DB backup twice every night, ~5 minutes apart — once from the bot's own `backupLoop`, once from the server-only `nightly-backup-backstop.sh` cron.

**Root cause**: the backstop script's dedup (`docker logs --since <window> | grep 'nightly backup sent'`) never actually matches in production — `docker logs --since` returns zero lines for any window on this host, verified directly on the server, even though the bot did log the line every night (confirmed via a windowless `docker logs | grep`, 6/6 nights). So the dedup silently always falls through and the backstop double-sends.

**Fix**:
- `internal/bot/background.go`: `sendLatestBackupTo` now touches `backups/.nightly-backup-sent` (via the existing host bind mount) after a successful send.
- `deploy/go/nightly-backup-backstop.sh` (new, previously untracked/server-only): dedupes on that marker's mtime (< 6h old = already sent tonight) instead of parsing container logs.
- `deploy/go/README.md`: documents the two production backup crons, which weren't written down anywhere before.
- `internal/bot/backup_test.go`: covers the marker create-and-refresh behavior.

No change to the bot's own nightly-send logic, the encoder, or any user-facing handler. CI runs `go build`, `go vet`, `gofmt -l`, and `go test -race`.

**Deploy note**: production (`/opt/chevalet-go-staging` on the server) isn't currently a git checkout — it's a file copy. After merge I'll sync the changed files over and swap in the tracked backstop script, then rebuild only the bot image and verify health + a clean cron dry-run before calling it done.