### PR TITLE
docs: fix wrong compose project name in cutover runbook

### DIFF
--- a/deploy/go/CUTOVER.md
+++ b/deploy/go/CUTOVER.md
@@ -57,7 +57,7 @@ when the file is absent) and remove the `volumes:` line in the prod compose.
 
 **5. Pre-build the Go image** so the cutover itself is instant:
 ```sh
-docker compose --env-file deploy/go/.env.prod -p chevalet-go-prod \
+docker compose --env-file deploy/go/.env.prod -p go \
   -f deploy/go/docker-compose.prod.yml build
 ```
 
@@ -79,7 +79,7 @@ docker stop telegram-bot
 
 **2. Start the Go bot** on the shared DB:
 ```sh
-docker compose --env-file deploy/go/.env.prod -p chevalet-go-prod \
+docker compose --env-file deploy/go/.env.prod -p go \
   -f deploy/go/docker-compose.prod.yml up -d
 ```
 
@@ -105,7 +105,7 @@ docker inspect chevalet-go-bot-prod --format '{{.State.Health.Status}}'   # -> h
 ## Rollback (instant — if anything looks wrong)
 
 ```sh
-docker compose -p chevalet-go-prod -f deploy/go/docker-compose.prod.yml down
+docker compose -p go -f deploy/go/docker-compose.prod.yml down
 docker start telegram-bot
 ```
 Same database, no data lost — the Python bot resumes polling within seconds.

--- a/deploy/go/docker-compose.cutover.yml
+++ b/deploy/go/docker-compose.cutover.yml
@@ -10,7 +10,7 @@
 # variable can be silently dropped.
 #
 # Run:
-#   docker compose -p chevalet-go-prod -f deploy/go/docker-compose.cutover.yml up -d --build
+#   docker compose -p go -f deploy/go/docker-compose.cutover.yml up -d --build
 # Rollback (instant): docker stop chevalet-go-bot-prod && docker start telegram-bot
 services:
   go-bot:

--- a/deploy/go/docker-compose.prod.yml
+++ b/deploy/go/docker-compose.prod.yml
@@ -14,7 +14,7 @@
 #                             (find it — see CUTOVER.md pre-flight step 2)
 #
 # Run with:
-#   docker compose --env-file deploy/go/.env.prod -p chevalet-go-prod \
+#   docker compose --env-file deploy/go/.env.prod -p go \
 #     -f deploy/go/docker-compose.prod.yml up -d --build
 
 services:


### PR DESCRIPTION
## Summary
- The cutover runbook documented `-p chevalet-go-prod`, but the actual production container was brought up under compose project name `go` (confirmed via `docker inspect chevalet-go-bot-prod --format '{{index .Config.Labels "com.docker.compose.project"}}'` on the prod host).
- Following the documented `-p chevalet-go-prod` flag creates a name conflict instead of recreating the existing container -- hit this while deploying de60a0d.
- Fixed all occurrences (`-p chevalet-go-prod` -> `-p go`) in `deploy/go/docker-compose.cutover.yml`, `deploy/go/docker-compose.prod.yml`, and `deploy/go/CUTOVER.md`.
- Docs-only change, no behavior change.

## Test plan
- [x] Grepped the repo for `chevalet-go-prod` -- no remaining occurrences.