### PR TITLE
fix: swallow benign "message is not modified" Telegram errors

### DIFF
--- a/internal/bot/prep.go
+++ b/internal/bot/prep.go
@@ -91,7 +91,8 @@ func (b *Bot) prep(fn Handler) handlers.Response {
 // handler. In order, it:
 //   - lets conversation state changes through untouched;
 //   - swallows the benign Telegram errors PTB ignored (an old callback query, a
-//     vanished reply target, or a Forbidden from a user who blocked the bot);
+//     vanished reply target, a Forbidden from a user who blocked the bot, or a
+//     "message is not modified" from re-triggering a menu already showing);
 //   - on a database error, replies the "database problem" notice to the user and
 //     reports it to ERROR_CHAT_ID (decorators.py `except psycopg2.Error`);
 //   - on a Telegram transport/network error, replies the "internet problem"
@@ -114,6 +115,8 @@ func (b *Bot) handleErr(tg *gotgbot.Bot, ctx *ext.Context, err error) error {
 	case errQueryTooOld(err):
 		return nil
 	case errReplyNotFound(err):
+		return nil
+	case errMessageNotModified(err): // user re-triggered a menu/state they were already on
 		return nil
 	case errForbidden(err): // covers "bot was blocked by the user" / "not a member"
 		return nil

--- a/internal/bot/tgerr.go
+++ b/internal/bot/tgerr.go
@@ -48,6 +48,13 @@ func errMessageIDInvalid(err error) bool { return descContains(err, "MESSAGE_ID_
 // errQueryTooOld: "Bad Request: query is too old and response timeout expired …".
 func errQueryTooOld(err error) bool { return descContains(err, "query is too old") }
 
+// errMessageNotModified: "Bad Request: message is not modified: specified new
+// message content and reply markup are exactly the same …". Harmless — it just
+// means the user re-triggered a menu/state they were already on (e.g. a double
+// tap, or pressing "back" while already at that menu), so the edit is a no-op
+// Telegram refuses rather than a real failure.
+func errMessageNotModified(err error) bool { return descContains(err, "message is not modified") }
+
 // errForbidden matches any HTTP 403 "Forbidden: …" Telegram error, mirroring the
 // PTB `except Forbidden` in is_reply_to_channel (e.g. a private channel the bot
 // was never added to).

--- a/internal/bot/tgerr_test.go
+++ b/internal/bot/tgerr_test.go
@@ -17,6 +17,7 @@ func TestErrorPredicates(t *testing.T) {
 	forbidden := &gotgbot.TelegramError{Code: 403, Description: "Forbidden: bot was blocked by the user"}
 	queryOld := &gotgbot.TelegramError{Code: 400, Description: "Bad Request: query is too old and response timeout expired"}
 	replyGone := &gotgbot.TelegramError{Code: 400, Description: "Bad Request: message to be replied not found"}
+	notModified := &gotgbot.TelegramError{Code: 400, Description: "Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message"}
 	pgErr := &pgconn.PgError{Code: "57014"}
 	netErr := &url.Error{Op: "Post", URL: "https://api.telegram.org", Err: errors.New("dial tcp: timeout")}
 	plain := errors.New("boom")
@@ -36,7 +37,10 @@ func TestErrorPredicates(t *testing.T) {
 	if !errReplyNotFound(replyGone) {
 		t.Error("errReplyNotFound should match")
 	}
-	if errQueryTooOld(netErr) || errReplyNotFound(plain) {
+	if !errMessageNotModified(notModified) {
+		t.Error("errMessageNotModified should match")
+	}
+	if errQueryTooOld(netErr) || errReplyNotFound(plain) || errMessageNotModified(plain) {
 		t.Error("desc predicates should be false for non-Telegram errors")
 	}
 


### PR DESCRIPTION
Closes #8

A user double-tapping a settings/my_links button (or pressing "back" while already at that menu) produces an identical `EditText` call, which Telegram rejects with "Bad Request: message is not modified: ...". That error wasn't in `internal/bot/tgerr.go`'s benign-error allowlist, so it escalated all the way to `onError`: a full incident got filed to ERROR_CHAT_ID with a tracking code, and the user got an unnecessary error reply for a completely harmless stray tap.

Adds `errMessageNotModified` alongside the existing `errQueryTooOld`/`errReplyNotFound`/`errForbidden` predicates and swallows it in `handleErr`, same pattern as the others. Test coverage added in `tgerr_test.go`.

No behavior change for real errors — only this specific, semantically-harmless Telegram rejection is now silently ignored instead of escalated.