### PR TITLE
feat(backup): send nightly backup to a configurable chat, not just an admin DM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,13 +54,14 @@ AI_URL=http://...
 AI_SESSION_ID=123456789
 AI_INTERVAL=5
 
-# --- Nightly DB backup to one admin's DM (optional, OFF by default) ---
-# When BACKUP_ADMIN_ID is set to one of the ADMINS ids above, the bot sends the
-# newest DB backup file to THAT chat (and only that chat — it never broadcasts)
-# once a day at BACKUP_TIME (Asia/Tehran, default 02:00). Leave BACKUP_ADMIN_ID
-# empty to disable. A non-ADMINS id is rejected at startup (guards against a typo
-# shipping the DB to the wrong chat).
-BACKUP_ADMIN_ID=
+# --- Nightly DB backup (optional, OFF by default) ---
+# When BACKUP_CHAT_ID is set, the bot sends the newest DB backup file to THAT
+# chat (and only that chat — it never broadcasts) once a day at BACKUP_TIME
+# (Asia/Tehran, default 02:17). Can be a personal DM (an ADMINS id) or a
+# private channel/supergroup id (negative, typically -100xxxxxxxxxx) — for a
+# channel, the bot must already be added there as an admin (with post
+# permission) or the send just fails. Leave BACKUP_CHAT_ID empty to disable.
+BACKUP_CHAT_ID=
 BACKUP_TIME=02:17
 
 # --- Misc ---

--- a/deploy/go/README.md
+++ b/deploy/go/README.md
@@ -59,13 +59,14 @@ on the server) runs two host-side cron jobs alongside the bot container:
 
 ```
 0 * * * *  /opt/chevalet-go-staging/deploy/go/backup.sh                      # hourly DB dump
-40 20 * * * /opt/chevalet-go-staging/deploy/go/nightly-backup-backstop.sh    # re-send if the bot's own nightly DM failed
+40 20 * * * /opt/chevalet-go-staging/deploy/go/nightly-backup-backstop.sh    # re-send if the bot's own nightly send failed
 ```
 
 `backup.sh` dumps `telegram-bot-db` hourly into the host `backups/` dir, which
 is bind-mounted into the container at `/app/backups`. Once a night at
-`BACKUP_TIME` (`internal/bot/background.go`'s `backupLoop`) the bot itself DMs
-the newest file to `BACKUP_ADMIN_ID` and touches `backups/.nightly-backup-sent`.
+`BACKUP_TIME` (`internal/bot/background.go`'s `backupLoop`) the bot itself
+sends the newest file to `BACKUP_CHAT_ID` — a personal DM or a private channel
+the bot administers — and touches `backups/.nightly-backup-sent`.
 `nightly-backup-backstop.sh` runs a few minutes after `BACKUP_TIME` and
 re-sends the same file only if that marker is missing or stale — see the
 script's header comment for why it checks a marker file rather than `docker

--- a/deploy/go/nightly-backup-backstop.sh
+++ b/deploy/go/nightly-backup-backstop.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Nightly DB-backup backstop for the Go bot.
 #
-# The bot itself DMs the newest backup to BACKUP_ADMIN_ID once a night at
-# BACKUP_TIME (see internal/bot/background.go: backupLoop/sendLatestBackupTo).
-# This script is a safety net that runs a few minutes later and re-sends the
-# same file ONLY if that in-process job didn't already succeed tonight —
-# otherwise the admin gets the backup twice.
+# The bot itself sends the newest backup to BACKUP_CHAT_ID (a DM or a private
+# channel) once a night at BACKUP_TIME (see internal/bot/background.go:
+# backupLoop/sendLatestBackupTo). This script is a safety net that runs a few
+# minutes later and re-sends the same file ONLY if that in-process job didn't
+# already succeed tonight — otherwise the destination gets the backup twice.
 #
 # Dedup: sendLatestBackupTo (re)touches backups/.nightly-backup-sent on every
 # successful send. This script skips if that marker is fresh (< 6h old).
@@ -34,7 +34,7 @@ mkdir -p "$(dirname "$LOG")"
 ts(){ date -u +%FT%TZ; }
 
 BOT_TOKEN=$(grep -E '^BOT_TOKEN=' "$ENVP" | cut -d= -f2- | tr -d '\r')
-ADMIN=$(grep -E '^BACKUP_ADMIN_ID=' "$ENVP" | cut -d= -f2- | tr -d '\r')
+CHAT_ID=$(grep -E '^BACKUP_CHAT_ID=' "$ENVP" | cut -d= -f2- | tr -d '\r')
 FORCE="${1:-}"
 
 if [ "$FORCE" != "force" ] && [ -f "$MARKER" ]; then
@@ -49,7 +49,7 @@ fi
 NEWEST=$(ls -1t "$BDIR"/backup_*.sql.gz 2>/dev/null | head -1)
 [ -z "$NEWEST" ] && { echo "$(ts) ERROR no backup file" >> "$LOG"; echo NO_FILE; exit 1; }
 
-RESP=$(curl -sS --max-time 150 -F chat_id="$ADMIN" -F document=@"$NEWEST" -F caption="DB backup (backstop): $(basename "$NEWEST")" "https://api.telegram.org/bot${BOT_TOKEN}/sendDocument")
+RESP=$(curl -sS --max-time 150 -F chat_id="$CHAT_ID" -F document=@"$NEWEST" -F caption="DB backup (backstop): $(basename "$NEWEST")" "https://api.telegram.org/bot${BOT_TOKEN}/sendDocument")
 if echo "$RESP" | grep -q '"ok":true'; then
   echo "$(ts) sent $(basename "$NEWEST")" >> "$LOG"; echo SENT_OK
 else

--- a/internal/bot/background.go
+++ b/internal/bot/background.go
@@ -40,9 +40,9 @@ func (b *Bot) startBackground(ctx context.Context) {
 		b.goBG(func() { b.gmgnLoop(ctx, b.Cfg.GMTime, true) })  // morning
 		b.goBG(func() { b.gmgnLoop(ctx, b.Cfg.GNTime, false) }) // night
 	}
-	// Nightly DB backup to one admin's DM — off unless BACKUP_ADMIN_ID is set.
-	if b.Cfg.BackupAdminID != 0 {
-		b.goBG(func() { b.backupLoop(ctx, b.Cfg.BackupTime, b.Cfg.BackupAdminID) })
+	// Nightly DB backup to a single chat — off unless BACKUP_CHAT_ID is set.
+	if b.Cfg.BackupChatID != 0 {
+		b.goBG(func() { b.backupLoop(ctx, b.Cfg.BackupTime, b.Cfg.BackupChatID) })
 	}
 }
 
@@ -199,11 +199,12 @@ func latestBackupFile(dir string, minAge time.Duration) (string, error) {
 	return newest, nil
 }
 
-// backupLoop delivers the newest DB backup to the configured admin's DM once a
-// day at hm (Asia/Tehran), mirroring gmgnLoop's daily-scheduler shape. It is
-// launched only when a valid BackupAdminID is configured (see startBackground),
-// so it can never run — or reach any chat other than that one id — by default.
-func (b *Bot) backupLoop(ctx context.Context, hm [2]int, adminID int64) {
+// backupLoop delivers the newest DB backup to the configured chat (a personal
+// DM or a private channel the bot administers) once a day at hm (Asia/Tehran),
+// mirroring gmgnLoop's daily-scheduler shape. It is launched only when a valid
+// BackupChatID is configured (see startBackground), so it can never run — or
+// reach any chat other than that one id — by default.
+func (b *Bot) backupLoop(ctx context.Context, hm [2]int, chatID int64) {
 	loc, err := time.LoadLocation("Asia/Tehran")
 	if err != nil {
 		slog.Error("backup: cannot load Asia/Tehran", "err", err)
@@ -221,7 +222,7 @@ func (b *Bot) backupLoop(ctx context.Context, hm [2]int, adminID int64) {
 			timer.Stop()
 			return
 		case <-timer.C:
-			b.sendLatestBackupTo(adminID)
+			b.sendLatestBackupTo(chatID)
 		}
 	}
 }
@@ -249,8 +250,9 @@ func touchNightlySentMarker(dir string) error {
 }
 
 // sendLatestBackupTo sends the newest settled backups/ file to a SINGLE chat id
-// (the nightly admin DM). Best-effort — every failure is logged, never fatal —
-// and it targets exactly one chat: it never iterates users / never broadcasts.
+// (the nightly backup destination — a DM or a channel). Best-effort — every
+// failure is logged, never fatal — and it targets exactly one chat: it never
+// iterates users / never broadcasts.
 // On any failure it also pings that same chat with a short text so a silent
 // stall (e.g. the dump one day exceeds Telegram's 50MB bot limit) is noticed.
 func (b *Bot) sendLatestBackupTo(chatID int64) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,11 +70,13 @@ type Config struct {
 	GMGroupTopic string
 
 	// Optional nightly DB-backup delivery: once a day at BackupTime (Asia/Tehran)
-	// the newest backups/ file is sent to the single chat BackupAdminID. The whole
-	// job is OFF when BackupAdminID == 0 (env BACKUP_ADMIN_ID unset), so it never
-	// runs — and never broadcasts — unless explicitly configured.
-	BackupAdminID int64
-	BackupTime    [2]int
+	// the newest backups/ file is sent to the single chat BackupChatID (a
+	// personal DM or, for a private channel, the bot must already be an admin
+	// there). The whole job is OFF when BackupChatID == 0 (env BACKUP_CHAT_ID
+	// unset), so it never runs — and never broadcasts — unless explicitly
+	// configured.
+	BackupChatID int64
+	BackupTime   [2]int
 
 	AIURL       string
 	AISessionID string
@@ -199,27 +201,26 @@ func Load() (*Config, error) {
 	c.GNTime = parseHHMM("GN_TIME", req("GN_TIME"), &errs)
 	c.GMGroupID = req("GM_GROUP_ID")
 
-	// Optional nightly-backup-to-admin job. Both keys are optional: the feature is
-	// off unless BACKUP_ADMIN_ID is a valid ADMINS id. BACKUP_TIME defaults to
-	// 02:17 (Asia/Tehran) — a quiet end-of-night snapshot, deliberately off the
-	// hourly backup cron's ":00" minute (belt-and-suspenders on top of the
-	// send-path's min-age guard).
+	// Optional nightly-backup job. Both keys are optional: the feature is off
+	// unless BACKUP_CHAT_ID is set. BACKUP_TIME defaults to 02:17 (Asia/Tehran)
+	// — a quiet end-of-night snapshot, deliberately off the hourly backup cron's
+	// ":00" minute (belt-and-suspenders on top of the send-path's min-age guard).
 	c.BackupTime = [2]int{2, 17}
 	if v := opt("BACKUP_TIME", ""); v != "" {
 		c.BackupTime = parseHHMM("BACKUP_TIME", v, &errs)
 	}
-	if v := opt("BACKUP_ADMIN_ID", ""); v != "" {
+	if v := opt("BACKUP_CHAT_ID", ""); v != "" {
+		// A personal chat id (positive) or a group/channel/supergroup id
+		// (negative, typically -100xxxxxxxxxx) — for the latter the bot must
+		// already be an admin of that chat, or the nightly send just fails.
+		// Only the integer syntax is validated at startup (fail loud on a typo);
+		// unlike ERROR_CHAT_ID/REPORT_CHAT_ID/GM_GROUP_ID this one is validated
+		// eagerly because a bad value silently arms a full-DB nightly send.
 		n, perr := strconv.ParseInt(v, 10, 64)
-		switch {
-		case perr != nil:
-			errs = append(errs, fmt.Sprintf("BACKUP_ADMIN_ID must be an integer (got %q)", v))
-		case !adminIDAllowed(c.Admins, v):
-			// Must be a trusted ADMINS member: a typo must NOT silently ship the
-			// full DB to a random user (or a negative group/channel id) every
-			// night. Fail loud at startup instead of exfiltrating quietly.
-			errs = append(errs, fmt.Sprintf("BACKUP_ADMIN_ID %q must be one of ADMINS %v", v, c.Admins))
-		default:
-			c.BackupAdminID = n
+		if perr != nil {
+			errs = append(errs, fmt.Sprintf("BACKUP_CHAT_ID must be an integer (got %q)", v))
+		} else {
+			c.BackupChatID = n
 		}
 	}
 
@@ -242,17 +243,6 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("config: %s", strings.Join(errs, "; "))
 	}
 	return c, nil
-}
-
-// adminIDAllowed reports whether id (a Telegram user-id string) is present in the
-// ADMINS list, tolerant of surrounding whitespace in the '|'-split entries.
-func adminIDAllowed(admins []string, id string) bool {
-	for _, a := range admins {
-		if strings.TrimSpace(a) == id {
-			return true
-		}
-	}
-	return false
 }
 
 // parseHHMM parses "HH:MM" into [hour, minute], mirroring config.py's

--- a/internal/config/config_backup_test.go
+++ b/internal/config/config_backup_test.go
@@ -2,29 +2,45 @@ package config
 
 import "testing"
 
-// TestAdminIDAllowed locks the BACKUP_ADMIN_ID guard: only a genuine ADMINS
-// member is accepted, so a typo (or a group/channel id) can't arm a nightly
-// full-DB send to the wrong chat.
-func TestAdminIDAllowed(t *testing.T) {
-	admins := []string{"1000000001", " 1000000002 ", "1000000003"} // note the padded entry
-	cases := []struct {
-		id   string
-		want bool
-	}{
-		{"1000000002", true}, // matches the whitespace-padded ADMINS entry
-		{"1000000001", true},
-		{"1000000003", true},
-		{"1000000009", false},     // single-digit typo -> rejected
-		{"-1001000000001", false}, // a group/channel id -> rejected
-		{"0", false},
-		{"", false},
+// TestBackupChatID locks BACKUP_CHAT_ID's parsing: optional (off, 0, by
+// default), accepts any valid int64 — including a negative channel/supergroup
+// id, unlike the old ADMINS-only BACKUP_ADMIN_ID this replaced — and rejects
+// non-integer syntax at startup (a typo must not silently arm a nightly
+// full-DB send to garbage).
+func TestBackupChatID(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("BACKUP_CHAT_ID", "")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v; want nil", err)
 	}
-	for _, c := range cases {
-		if got := adminIDAllowed(admins, c.id); got != c.want {
-			t.Errorf("adminIDAllowed(%q) = %v; want %v", c.id, got, c.want)
-		}
+	if c.BackupChatID != 0 {
+		t.Errorf("BackupChatID with BACKUP_CHAT_ID unset = %d; want 0 (feature off)", c.BackupChatID)
 	}
-	if adminIDAllowed(nil, "1000000002") {
-		t.Error("adminIDAllowed(nil, ...) = true; want false (no admins configured)")
+
+	setRequiredEnv(t)
+	t.Setenv("BACKUP_CHAT_ID", "1000000002") // a personal chat/admin DM
+	c, err = Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v; want nil", err)
+	}
+	if c.BackupChatID != 1000000002 {
+		t.Errorf("BackupChatID = %d; want 1000000002", c.BackupChatID)
+	}
+
+	setRequiredEnv(t)
+	t.Setenv("BACKUP_CHAT_ID", "-1001000000001") // a private channel/supergroup id
+	c, err = Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v; want nil", err)
+	}
+	if c.BackupChatID != -1001000000001 {
+		t.Errorf("BackupChatID = %d; want -1001000000001 (channel ids must be accepted)", c.BackupChatID)
+	}
+
+	setRequiredEnv(t)
+	t.Setenv("BACKUP_CHAT_ID", "not-an-int")
+	if _, err := Load(); err == nil {
+		t.Error("Load() with BACKUP_CHAT_ID=not-an-int: want an error, got nil")
 	}
 }


### PR DESCRIPTION
Requested: send the nightly DB backup to a private channel instead of the admin's personal DM (safer than a personal chat for a full DB dump).

**Change**: `BACKUP_ADMIN_ID` -> `BACKUP_CHAT_ID`. The old name required the destination to be one of `ADMINS` (a personal DM only) as a typo-guard. That guard doesn't make sense for a channel id, so it's dropped -- `BACKUP_CHAT_ID` now accepts any valid int64 (including a negative channel/supergroup id), matching how `GM_GROUP_ID`/`ERROR_CHAT_ID`/`REPORT_CHAT_ID` are already handled elsewhere in `config.go`. It's still validated as a proper integer at startup and still off by default.

**To use a channel**: create a private channel, add the bot to it as an admin with post permission, get the channel's numeric id (negative, `-100xxxxxxxxxx`), set `BACKUP_CHAT_ID` to that.

**Files**: `internal/config/config.go` (+test), `internal/bot/background.go` (renamed field/param only, logic unchanged), `.env.example`, `deploy/go/README.md`, `deploy/go/nightly-backup-backstop.sh` (env var name).

No change to `/admin backup` (the manual command replies wherever it was invoked, independent of this setting).