### PR TITLE
ci: deploy on version tags instead of every push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,16 @@ name: CI
 on:
   push:
     branches: ["**"]
+    # Pushing a vX.Y.Z tag is what deploys to production — see the deploy job.
+    tags: ["v*.*.*"]
   pull_request:
+  # Redeploy or roll back to any existing tag without pushing a new one.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing version tag to deploy to production (e.g. v1.1.0)"
+        required: true
+        type: string
 
 jobs:
   build-test:
@@ -11,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # On workflow_dispatch, test the tag being deployed rather than
+          # whatever branch the run was launched from — otherwise the gate in
+          # front of a rollback would be testing unrelated code. Empty for
+          # push/pull_request, where the default checkout is already correct.
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -39,16 +54,21 @@ jobs:
         run: go test -race -count=1 ./...
 
   deploy:
-    name: deploy to production
+    name: deploy ${{ github.event.inputs.tag || github.ref_name }} to production
     needs: build-test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Deploys are deliberate: either a vX.Y.Z tag was pushed, or someone asked
+    # for a specific tag via the Run workflow button. Never on a branch push,
+    # never on a PR — pushing to main no longer touches production.
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    environment: production
     steps:
       # The server's authorized_keys entry for this key is forced-command
-      # restricted, so it can only ever run one exact deploy command
-      # regardless of what's requested here — this script is documentation,
-      # the server enforces the actual command. This is the LIVE bot serving
-      # real users, so this only runs on main, never on other branches/PRs.
+      # restricted to /usr/local/bin/deploy-chevalet.sh (source of truth:
+      # deploy/go/deploy-tag.sh). That script accepts nothing but a semver tag
+      # name, so this key cannot run anything else on the box no matter what is
+      # requested here. The script checks out that exact tag, rebuilds, waits for
+      # the container to report healthy, and rolls back by itself if it doesn't.
       - name: SSH deploy
         uses: appleboy/ssh-action@v1
         with:
@@ -56,4 +76,4 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: cd /opt/chevalet-go-staging && git pull --ff-only && cd deploy/go && docker compose -p go -f docker-compose.cutover.yml up -d --build
+          script: deploy ${{ github.event.inputs.tag || github.ref_name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ CI (`.github/workflows/ci.yml`) runs build, vet, gofmt-check, and
 itself automatically when `DB_HOST` is unset, so CI runs everything except
 that one without needing a database.
 
+Production deploys are **tag-driven**: pushing a `vX.Y.Z` tag deploys that exact
+tag; pushing to `main` only runs the tests. Rollback is a `workflow_dispatch` run
+with an older tag. Don't add a branch-push deploy back —
+[`deploy/go/RELEASING.md`](deploy/go/RELEASING.md) explains the flow and why the
+server-side forced command validates the tag itself.
+
 To live-test end-to-end against a throwaway Postgres with a staging bot
 token, use the isolated stack in [`deploy/go/`](deploy/go/README.md) (needs
 `PROXY` — Telegram is generally unreachable without one).

--- a/README.md
+++ b/README.md
@@ -128,9 +128,25 @@ To live-test against a throwaway PostgreSQL isolated from production (with a
 
 ## Production deployment & cutover
 
-For deploying, and for the near-zero-downtime cutover from the original Python
-bot to this Go bot — they share the same database schema, so no data migration
-is needed — see [`MIGRATION.md`](MIGRATION.md).
+Production deploys are **tag-driven**: pushing a `vX.Y.Z` tag is what ships
+code. Pushing to `main` runs the tests but does *not* touch production.
+
+```sh
+git tag -a v1.2.0 -m "what changed"
+git push origin v1.2.0        # CI tests it, then deploys that exact tag
+```
+
+To roll back (or redeploy any earlier version), run the **CI** workflow from the
+Actions tab with the target tag as input — no new tag or rebuild needed, since
+each release keeps its own image on the server.
+
+The full release/rollback runbook, the server-side script, and how the
+forced-command restriction on the deploy key works are documented in
+[`deploy/go/RELEASING.md`](deploy/go/RELEASING.md).
+
+For the near-zero-downtime cutover from the original Python bot to this Go bot —
+they share the same database schema, so no data migration is needed — see
+[`MIGRATION.md`](MIGRATION.md).
 
 ## Contributing
 

--- a/deploy/go/RELEASING.md
+++ b/deploy/go/RELEASING.md
@@ -1,0 +1,92 @@
+# Releasing & rolling back production
+
+Production (`@Chevalet_bot`, container `chevalet-go-bot-prod` on the Germany
+server) is deployed **only** by pushing a version tag, or by asking for a
+specific tag from the Actions tab. Pushing to `main` runs the test suite and
+stops there — merging no longer changes what users are talking to.
+
+## Cut a release
+
+```sh
+git checkout main && git pull
+git tag -a v1.2.0 -m "short summary of what changed"
+git push origin v1.2.0
+```
+
+CI then runs `build / vet / fmt / test -race` **against that tag**, and only on
+success deploys it. Watch the run in the Actions tab; the job is named
+`deploy v1.2.0 to production`.
+
+Versioning is plain semver: bump patch for fixes, minor for new behavior. The
+tag must match `vX.Y.Z` exactly — the server refuses anything else, including
+`v1.2`, `v1.2.3-rc1`, and branch names.
+
+## Roll back (or redeploy an old version)
+
+Actions tab → **CI** → *Run workflow* → enter the tag, e.g. `v1.1.0`.
+
+Rollback does not rebuild: the server keeps the last 5 versioned images
+(`chevalet-go-bot:v1.1.0`, …), so it re-points at an image that already exists
+and restarts the container. That makes rollback both fast and independent of
+whether a build would still succeed right now.
+
+If Actions itself is unavailable, the same thing by hand:
+
+```sh
+ssh germany
+tail -f /var/log/chevalet-deploy.log        # what past deploys did
+cd /opt/chevalet-go-staging && git fetch --tags
+git checkout --detach v1.1.0
+cd deploy/go && IMAGE_TAG=v1.1.0 docker compose -p go -f docker-compose.cutover.yml up -d
+```
+
+## How the deploy is restricted
+
+`.github/workflows/ci.yml` sends exactly one string over SSH: `deploy vX.Y.Z`.
+It does **not** get to choose the command that runs. The deploy key's entry in
+the server's `/root/.ssh/authorized_keys` is forced-command restricted to:
+
+```
+command="/usr/local/bin/deploy-chevalet.sh",no-agent-forwarding,no-X11-forwarding,no-port-forwarding,no-pty
+```
+
+so whatever a holder of that key asks for lands in `SSH_ORIGINAL_COMMAND` and is
+treated as untrusted input. [`deploy-tag.sh`](deploy-tag.sh) — the source of
+truth for that script — extracts a tag only if the payload matches
+`^v[0-9]+\.[0-9]+\.[0-9]+$`, never eval's it, and refuses everything else with
+exit code 2. A compromised CI token therefore cannot run arbitrary commands on
+the box; it can only deploy some tag that already exists in this repo.
+
+> Before this, the forced command was a fixed
+> `git pull --ff-only && docker compose up -d --build`. That always deployed the
+> tracked *branch*, so it could not honor a requested version at all — a
+> "deploy v1.2.0" run would have shipped whatever `main` pointed at.
+
+## What the deploy script does
+
+1. Refuses the request unless it is exactly `deploy vX.Y.Z`.
+2. `git fetch --tags` and resolves the tag; aborts if it doesn't exist.
+3. Records the current commit and image so it can undo the change.
+4. Checks out the tag detached and runs `docker compose up -d --build` with
+   `IMAGE_TAG` set, so the image is tagged with the version (and `:prod` is
+   re-pointed at it afterwards). Skips `--build` when that version's image is
+   already on disk.
+5. Waits up to 180s for the container's healthcheck to report `healthy`.
+6. **Rolls back automatically** to the previous commit and image if it doesn't,
+   logs the container's last 30 lines, and exits non-zero so CI goes red.
+7. Prunes versioned images beyond the newest 5.
+
+Every run appends to `/var/log/chevalet-deploy.log` on the server.
+
+## Updating the script itself
+
+The script runs from `/usr/local/bin/`, so editing it in the repo is not enough —
+after merging a change to `deploy-tag.sh`, reinstall it:
+
+```sh
+ssh germany 'install -m 755 /opt/chevalet-go-staging/deploy/go/deploy-tag.sh /usr/local/bin/deploy-chevalet.sh'
+```
+
+Note the ordering trap: the running script is what deploys the tag that contains
+the new script, so a change to `deploy-tag.sh` takes effect on the deploy
+*after* the one that ships it, unless you reinstall by hand as above.

--- a/deploy/go/deploy-tag.sh
+++ b/deploy/go/deploy-tag.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Production deploy for a specific version tag.
+#
+# This is the script the deploy key's forced command in /root/.ssh/authorized_keys
+# points at. It is installed to /usr/local/bin/deploy-chevalet.sh; this copy in the
+# repo is the source of truth — see "Installing" below.
+#
+# WHY A SCRIPT INSTEAD OF A FORCED COMMAND STRING: the previous forced command was
+# `git pull --ff-only && docker compose up -d --build`, which always deploys the
+# tracked *branch*. That silently ignores which version CI asked for — a "deploy
+# v1.2.0" run would ship whatever main happened to point at. Deploying an exact tag
+# needs the tag as input, so the forced command has to be a script that reads it.
+#
+# The whole point of a forced command is that the client cannot choose what runs, so
+# the input arriving in SSH_ORIGINAL_COMMAND is treated as untrusted: the only thing
+# ever extracted from it is a tag name matching ^v[0-9]+\.[0-9]+\.[0-9]+$, and that
+# string is never eval'd or interpolated into a shell command. Anything else is
+# refused. A caller holding the key can therefore only ever deploy some existing
+# semver tag of this repo — nothing else.
+#
+# Usage (from CI, over ssh):  deploy vX.Y.Z
+#
+# Installing (or updating) on the server:
+#   install -m 755 /opt/chevalet-go-staging/deploy/go/deploy-tag.sh \
+#           /usr/local/bin/deploy-chevalet.sh
+# and the authorized_keys entry for the deploy key must read:
+#   command="/usr/local/bin/deploy-chevalet.sh",no-agent-forwarding,\
+#   no-X11-forwarding,no-port-forwarding,no-pty ssh-ed25519 AAAA... github-actions-deploy@chevaletanonbot
+set -euo pipefail
+
+REPO=/opt/chevalet-go-staging
+COMPOSE_DIR="$REPO/deploy/go"
+COMPOSE_FILE=docker-compose.cutover.yml
+PROJECT=go
+CONTAINER=chevalet-go-bot-prod
+IMAGE=chevalet-go-bot
+LOGFILE=/var/log/chevalet-deploy.log
+KEEP_IMAGES=5          # versioned images retained for instant rollback
+HEALTH_TIMEOUT=180     # seconds to wait for the container to report healthy
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOGFILE"; }
+die() { log "FAILED: $*"; exit 1; }
+
+# ---------------------------------------------------------------- parse input
+# drone-ssh (appleboy/ssh-action) sends the workflow's `script` as the original
+# command, and may pass it as several lines. Scan the lines for one that is
+# exactly `deploy vX.Y.Z` and ignore everything else, rather than trusting the
+# whole payload.
+TAG=""
+while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*deploy[[:space:]]+(v[0-9]+\.[0-9]+\.[0-9]+)[[:space:]]*$ ]]; then
+        TAG="${BASH_REMATCH[1]}"
+        break
+    fi
+done <<< "${SSH_ORIGINAL_COMMAND:-}"
+
+if [[ -z "$TAG" ]]; then
+    log "REFUSED: expected 'deploy vX.Y.Z', got: ${SSH_ORIGINAL_COMMAND:-<empty>}"
+    echo "refused: this key only deploys a semver tag; expected 'deploy vX.Y.Z'" >&2
+    exit 2
+fi
+
+log "=== deploy requested: $TAG ==="
+cd "$REPO"
+
+# ------------------------------------------------- resolve the requested tag
+git fetch --tags --prune --force origin >>"$LOGFILE" 2>&1 || die "git fetch failed"
+
+TARGET_COMMIT=$(git rev-parse --verify --quiet "refs/tags/${TAG}^{commit}") \
+    || die "tag $TAG does not exist on origin"
+
+# Remember where to go back to if the new version turns out to be unhealthy.
+PREV_COMMIT=$(git rev-parse HEAD)
+PREV_IMAGE=$(docker inspect --format '{{.Config.Image}}' "$CONTAINER" 2>/dev/null || echo "")
+log "current: ${PREV_COMMIT:0:7} (image ${PREV_IMAGE:-none}) -> target: $TAG (${TARGET_COMMIT:0:7})"
+
+if [[ "$PREV_COMMIT" == "$TARGET_COMMIT" ]]; then
+    log "note: $TAG is the commit already checked out; redeploying anyway"
+fi
+
+# ----------------------------------------------------------------- roll forward
+# deploy_commit <commit> <image_tag> [extra compose args...]
+deploy_commit() {
+    local commit="$1" image_tag="$2"
+    shift 2
+    git checkout --detach --force "$commit" >>"$LOGFILE" 2>&1 \
+        || return 1
+    cd "$COMPOSE_DIR"
+    # IMAGE_TAG is consumed by docker-compose.cutover.yml, so each version keeps
+    # its own image and a rollback can reuse one instead of rebuilding.
+    IMAGE_TAG="$image_tag" docker compose -p "$PROJECT" -f "$COMPOSE_FILE" \
+        up -d "$@" >>"$LOGFILE" 2>&1 || { cd "$REPO"; return 1; }
+    cd "$REPO"
+}
+
+# An image already built for this tag means this is a rollback/redeploy: reuse it
+# and skip the rebuild, which is both far faster and avoids depending on the
+# build succeeding again right now.
+BUILD_ARGS=(--build)
+if docker image inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
+    BUILD_ARGS=()
+    log "image ${IMAGE}:${TAG} already present — reusing it, skipping rebuild"
+fi
+
+deploy_commit "$TARGET_COMMIT" "$TAG" "${BUILD_ARGS[@]}" || die "build/up failed for $TAG"
+
+# ------------------------------------------------------------- verify health
+log "waiting for $CONTAINER to report healthy (timeout ${HEALTH_TIMEOUT}s)"
+healthy=false
+for _ in $(seq 1 "$HEALTH_TIMEOUT"); do
+    state=$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo missing)
+    running=$(docker inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null || echo false)
+    if [[ "$state" == healthy ]]; then healthy=true; break; fi
+    if [[ "$running" != true ]]; then log "container stopped running (health=$state)"; break; fi
+    sleep 1
+done
+
+if [[ "$healthy" != true ]]; then
+    log "UNHEALTHY after deploy of $TAG — rolling back to ${PREV_COMMIT:0:7}"
+    docker logs "$CONTAINER" --tail 30 >>"$LOGFILE" 2>&1 || true
+    prev_tag="${PREV_IMAGE##*:}"
+    [[ -z "$prev_tag" || "$prev_tag" == "$PREV_IMAGE" ]] && prev_tag=prod
+    # No --build on the way back: the previous image is already on disk, and a
+    # rollback must not depend on a build succeeding.
+    if deploy_commit "$PREV_COMMIT" "$prev_tag"; then
+        log "rolled back to ${PREV_COMMIT:0:7} (image ${IMAGE}:${prev_tag})"
+    else
+        log "ROLLBACK FAILED — manual intervention needed on $CONTAINER"
+    fi
+    die "$TAG did not become healthy; production left on the previous version"
+fi
+
+# `:prod` stays a moving pointer at whatever is live, so CUTOVER.md's manual
+# commands and anything else referencing :prod keep working.
+docker tag "${IMAGE}:${TAG}" "${IMAGE}:prod"
+
+# ------------------------------------------------------------------ housekeeping
+# Keep the newest few versioned images so rollbacks stay instant; drop the rest.
+docker images --format '{{.Repository}}:{{.Tag}}\t{{.CreatedAt}}' \
+    | grep -E "^${IMAGE}:v[0-9]+\.[0-9]+\.[0-9]+\b" \
+    | sort -k2 -r | tail -n +$((KEEP_IMAGES + 1)) | cut -f1 \
+    | while read -r old; do
+          log "pruning old image $old"
+          docker rmi "$old" >>"$LOGFILE" 2>&1 || true
+      done
+
+log "=== deployed $TAG (${TARGET_COMMIT:0:7}) successfully, $CONTAINER healthy ==="
+echo "deployed $TAG (${TARGET_COMMIT:0:7}); $CONTAINER healthy"

--- a/deploy/go/docker-compose.cutover.yml
+++ b/deploy/go/docker-compose.cutover.yml
@@ -17,7 +17,10 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile
-    image: chevalet-go-bot:prod
+    # IMAGE_TAG is set by deploy-tag.sh to the version being deployed, so each
+    # release keeps its own image and rolling back reuses one instead of
+    # rebuilding. Unset (i.e. any manual `docker compose` run) behaves as before.
+    image: chevalet-go-bot:${IMAGE_TAG:-prod}
     container_name: chevalet-go-bot-prod
     restart: unless-stopped
     init: true


### PR DESCRIPTION
## Why

Two problems with the current setup:

1. **Every push to `main` redeployed the live bot.** No deliberate release step, no way to say *which* version is in production.
2. **The deploy job had never once succeeded.** Both runs that triggered it failed — the server's forced command ran `git pull --ff-only` with no upstream configured, so it fetched and then died. `origin/main` advanced while CI never moved the working tree.

There was also a latent trap: the only existing tag, `v1.0.0`, is **5 commits behind** what is actually running, so any naive "deploy the latest tag" would have rolled production backwards.

## What changed

Deploys are now **tag-driven**:

- Push `vX.Y.Z` → CI tests **that tag**, then deploys exactly it.
- Push to `main` → tests only. Merging no longer touches production.
- `workflow_dispatch` with a tag input → deploy/redeploy any existing tag. This is the rollback path.

### Why the server side had to change too

A specific version cannot be deployed by a fixed `git pull --ff-only` forced command — that always ships the tracked *branch*, so a "deploy v1.2.0" run would have silently shipped whatever `main` pointed at. The tag has to arrive as input, so the forced command becomes `deploy-tag.sh`.

That input is untrusted (whoever holds the CI key controls it), so the script extracts a tag **only** from a payload matching `^v[0-9]+\.[0-9]+\.[0-9]+$`, never `eval`s it, and refuses everything else with exit 2. The key still cannot run arbitrary commands on the box — verified with 28 cases covering `;`, `&&`, `|`, `$(…)`, backticks, path traversal, and non-semver refs (all refused; valid tags accepted).

### Deploys now verify themselves

The script waits up to 180s for the container's healthcheck and **rolls back automatically** to the previous commit and image if it never reports healthy, logging the container's last 30 lines and exiting non-zero. A bad release no longer leaves production down.

Images are tagged with their version (`IMAGE_TAG` in the cutover compose file, defaulting to `prod` so manual `docker compose` runs behave exactly as before), so rollback re-points at an image already on disk — a restart, not a rebuild, and it doesn't depend on the build still succeeding. Newest 5 kept.

## Verification

- `go build` / `go vet` / `gofmt` / `go test -race -count=1 ./...` — all green (7 packages).
- `shellcheck` clean on `deploy-tag.sh`.
- Workflow YAML parses; triggers and the `if` guard confirmed.
- Parser: 28/28 accept/refuse cases pass.

**Not yet installed on the server** — `/usr/local/bin/deploy-chevalet.sh` and the `authorized_keys` forced command are updated after this merges, then `v1.1.0` is cut at the currently-live commit so the first real run is a code no-op that exercises the whole pipeline.

Docs: [`deploy/go/RELEASING.md`](deploy/go/RELEASING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)