### PR TITLE
fix(encoder): reject non-canonical callback tokens

### DIFF
--- a/internal/encoder/token.go
+++ b/internal/encoder/token.go
@@ -46,6 +46,22 @@ const (
 // use of the same server secret. "v1" allows a future scheme bump.
 const tokenKeyLabel = "chevalet:callback-token:v1"
 
+// tokenEnc is base64url WITHOUT padding, in Strict mode.
+//
+// Strict matters: tokenRawLen (23) bytes encode to 31 base64 chars, which hold
+// 186 bits for 184 bits of payload — so the final character carries 2 bits that
+// are not part of the message. The non-strict decoder silently ignores them, which
+// made every token have FOUR distinct string encodings that all opened to the same
+// uid (…Ku8/…Ku9/…Ku-/…Ku_). Nothing here keys off the token string, so that was
+// malleability rather than an exploitable hole, but non-canonical ciphertext is
+// worth refusing on principle — and it made TestTokenTamperRejected fail ~6% of
+// runs (whenever flipping the last char changed only padding bits), which is a
+// tamper test that silently stops testing tampering.
+//
+// Encoding is unaffected (Go always writes those bits as zero), so every token
+// ever issued still opens — only malleated variants are now rejected.
+var tokenEnc = base64.RawURLEncoding.Strict()
+
 // errNoRand is returned by Seal if the OS CSPRNG fails — the caller must fail the
 // send rather than emit a token with a predictable nonce (which would silently
 // destroy unlinkability).
@@ -126,7 +142,7 @@ func (tc *TokenCipher) Seal(uid int64, aad []byte) (string, error) {
 	raw = append(raw, nonce[:]...)
 	raw = append(raw, ct...)
 	raw = append(raw, tag...)
-	return base64.RawURLEncoding.EncodeToString(raw), nil
+	return tokenEnc.EncodeToString(raw), nil
 }
 
 // Open reverses Seal: returns (uid, true) iff token is a well-formed, key-valid,
@@ -136,7 +152,7 @@ func (tc *TokenCipher) Open(token string, aad []byte) (int64, bool) {
 	if !tc.Ready() {
 		return 0, false
 	}
-	raw, err := base64.RawURLEncoding.DecodeString(token)
+	raw, err := tokenEnc.DecodeString(token)
 	if err != nil || len(raw) != tokenRawLen {
 		return 0, false
 	}

--- a/internal/encoder/token_test.go
+++ b/internal/encoder/token_test.go
@@ -46,13 +46,52 @@ func TestTokenTamperRejected(t *testing.T) {
 	tc := NewTokenCipher(testBotToken)
 	tok, _ := tc.Seal(1000000002, nil)
 	b := []byte(tok)
-	for _, i := range []int{0, len(b) / 2, len(b) - 1} {
+	// Every position, not a sample of three: the flip is cheap and a gap here is
+	// a gap in the tamper guarantee. This used to test only 0, len/2 and len-1,
+	// and the len-1 case was the one that misbehaved (see below).
+	for i := range b {
 		orig := b[i]
 		b[i] = flipChar(orig)
 		if _, ok := tc.Open(string(b), nil); ok {
-			t.Errorf("tampered token (byte %d) opened; want reject", i)
+			t.Errorf("tampered token (byte %d of %d) opened; want reject", i, len(b))
 		}
 		b[i] = orig
+	}
+}
+
+// TestTokenCanonical pins down that a token has exactly ONE valid string form.
+//
+// The last base64 char carries 2 bits that are not payload (23 bytes = 184 bits
+// into 31 chars = 186 bits). While Open used the non-strict decoder those bits
+// were ignored, so all 4 values of that char opened to the same uid, and
+// TestTokenTamperRejected only noticed when the flip happened to cross that
+// boundary — a ~6%-of-runs failure that read as flakiness rather than as the real
+// finding. Asserting canonicality directly makes a regression here deterministic.
+func TestTokenCanonical(t *testing.T) {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	tc := NewTokenCipher(testBotToken)
+	uid := int64(1000000002)
+
+	// Seal many tokens so every possible value of the final char gets covered,
+	// rather than depending on which one this run's random nonce happened to yield.
+	for n := 0; n < 200; n++ {
+		tok, err := tc.Seal(uid, nil)
+		if err != nil {
+			t.Fatalf("Seal: %v", err)
+		}
+		opened := 0
+		for i := 0; i < len(alphabet); i++ {
+			variant := tok[:len(tok)-1] + string(alphabet[i])
+			if _, ok := tc.Open(variant, nil); ok {
+				opened++
+				if variant != tok {
+					t.Errorf("non-canonical token opened: %q (canonical %q)", variant, tok)
+				}
+			}
+		}
+		if opened != 1 {
+			t.Fatalf("%d final-char variants of %q opened; want exactly 1", opened, tok)
+		}
 	}
 }
 


### PR DESCRIPTION
## What was wrong

`TestTokenTamperRejected` failed **~6% of runs at random** — it went red on the `main` merge of #11, having passed on that same code in the PR. That looked like flakiness. It wasn't: the test was correctly reporting a real property of the tokens.

`tokenRawLen` is 23 bytes = 184 bits. base64url encodes that into 31 chars = 186 bits, so **the final character carries 2 bits that are not payload**, and the non-strict decoder ignores them. Every token therefore had **four valid string forms**, all opening to the same uid:

```
vvJ03-qwnTE6Y7tzPv_1rKDobMKBKu8   ← canonical
vvJ03-qwnTE6Y7tzPv_1rKDobMKBKu9   ← also opened
vvJ03-qwnTE6Y7tzPv_1rKDobMKBKu-   ← also opened
vvJ03-qwnTE6Y7tzPv_1rKDobMKBKu_   ← also opened
```

`flipChar` maps `'A'→'B'`, so when the last char was `'A'` the flip changed *only* padding — identical raw bytes, valid MAC, "tampered" token opened. `'A'` occurs there 1/16 of the time; measured **1213/20000 = 6.07%**.

## Severity: low — malleability, not an exploitable hole

It leaks nothing and cannot forge a different uid. I checked whether anything keys off the token string for dedup, replay protection, or rate limiting — nothing does (the once-only "seen" behaviour works by editing the keyboard). The real cost was a **tamper test that had silently stopped testing tampering**, on a test that now gates production deploys.

## The fix

Decoding uses `base64.RawURLEncoding.Strict()`, so a token has exactly one valid encoding.

**Backward compatible:** encoding is unchanged — Go's encoder already wrote those bits as zero, so every token ever issued still opens (confirmed: only 16 distinct final chars are ever produced, all with zero padding bits). Only malleated variants are now refused. `TokenCipher` is explicitly *not* the frozen compatibility contract (`EncodeChevaletID` is), and the golden vectors are untouched.

## Tests

- `TestTokenCanonical` (new) asserts the one-valid-form property directly across 200 fresh tokens, so a regression fails **deterministically** rather than 6% of the time.
- `TestTokenTamperRejected` now flips **every** position instead of three samples.

Both were confirmed to fail with the fix reverted:

```
--- FAIL: TestTokenTamperRejected
    token_test.go:56: tampered token (byte 30 of 31) opened; want reject
--- FAIL: TestTokenCanonical
    token_test.go:88: non-canonical token opened: "…Qgp" (canonical "…Qgo")
    token_test.go:93: 4 final-char variants opened; want exactly 1
```

## Verification

- `go test -race -count=300 ./internal/encoder/` — **300 consecutive clean runs** (at 6%/run, ~10⁻⁸ by luck).
- Full gate green: build, vet, gofmt, `go test -race -count=1 ./...` (7 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)