### PR TITLE
ci: verify a deploy is actually live, not just healthy

### DIFF
--- a/deploy/go/RELEASING.md
+++ b/deploy/go/RELEASING.md
@@ -72,9 +72,31 @@ the box; it can only deploy some tag that already exists in this repo.
    re-pointed at it afterwards). Skips `--build` when that version's image is
    already on disk.
 5. Waits up to 180s for the container's healthcheck to report `healthy`.
-6. **Rolls back automatically** to the previous commit and image if it doesn't,
-   logs the container's last 30 lines, and exits non-zero so CI goes red.
-7. Prunes versioned images beyond the newest 5.
+6. Waits up to 90s for the `bot polling` log line from *this* container start,
+   then settles 20s and re-checks that the container is still running and its
+   restart count hasn't moved.
+7. **Rolls back automatically** to the previous commit and image if any of that
+   fails, logs the container's last 30 lines, and exits non-zero so CI goes red.
+8. Prunes versioned images beyond the newest 5.
+
+### Why healthy alone isn't enough
+
+The Docker healthcheck is a bare TCP connect to the health port, and `main.go`
+opens that listener *before* `Run()` calls `StartPolling` — so a container reports
+`healthy` before it has ever reached Telegram. If polling then fails, `main`
+exits, the restart policy loops the container, and each fresh start re-opens the
+health port, so snapshots keep looking fine. A deploy could therefore be reported
+green while the bot was dead to users.
+
+Hence the two extra gates: the `bot polling` line is positive proof that
+`StartPolling` returned successfully (Telegram accepted `getUpdates`), and the
+restart-count comparison across a settle window catches a crash-loop that
+instantaneous checks miss.
+
+A single `level=ERROR` after start is **not** a rollback trigger — that is often
+ordinary traffic, such as a send to a user who has blocked the bot. Those lines
+are counted and logged instead, because auto-reverting a good release on a benign
+error would be worse than surfacing it. `panic:` and `level=FATAL` do roll back.
 
 Every run appends to `/var/log/chevalet-deploy.log` on the server.
 

--- a/deploy/go/deploy-tag.sh
+++ b/deploy/go/deploy-tag.sh
@@ -37,6 +37,8 @@ IMAGE=chevalet-go-bot
 LOGFILE=/var/log/chevalet-deploy.log
 KEEP_IMAGES=5          # versioned images retained for instant rollback
 HEALTH_TIMEOUT=180     # seconds to wait for the container to report healthy
+POLL_TIMEOUT=90        # seconds to wait for proof that Telegram polling started
+SETTLE_SECONDS=20      # quiet period used to detect a crash-loop after startup
 
 log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOGFILE"; }
 die() { log "FAILED: $*"; exit 1; }
@@ -115,10 +117,10 @@ for _ in $(seq 1 "$HEALTH_TIMEOUT"); do
     sleep 1
 done
 
-if [[ "$healthy" != true ]]; then
-    log "UNHEALTHY after deploy of $TAG — rolling back to ${PREV_COMMIT:0:7}"
+rollback() {
+    log "$1 — rolling back to ${PREV_COMMIT:0:7}"
     docker logs "$CONTAINER" --tail 30 >>"$LOGFILE" 2>&1 || true
-    prev_tag="${PREV_IMAGE##*:}"
+    local prev_tag="${PREV_IMAGE##*:}"
     [[ -z "$prev_tag" || "$prev_tag" == "$PREV_IMAGE" ]] && prev_tag=prod
     # No --build on the way back: the previous image is already on disk, and a
     # rollback must not depend on a build succeeding.
@@ -127,8 +129,60 @@ if [[ "$healthy" != true ]]; then
     else
         log "ROLLBACK FAILED — manual intervention needed on $CONTAINER"
     fi
-    die "$TAG did not become healthy; production left on the previous version"
+    die "$TAG was not verified live; production left on the previous version"
+}
+
+if [[ "$healthy" != true ]]; then
+    rollback "UNHEALTHY after deploy of $TAG"
 fi
+
+# --------------------------------------------------- verify it is actually LIVE
+# `healthy` is necessary but NOT sufficient. The healthcheck is a bare TCP connect
+# to the health port, and main.go opens that listener BEFORE Run() calls
+# StartPolling — so a container reports healthy before it has ever reached
+# Telegram. If polling then fails, main exits, Docker's restart policy loops it,
+# and without this check the deploy would already have been reported green.
+#
+# So require positive evidence from THIS container start: the "bot polling" line
+# (which is only logged after StartPolling succeeded, i.e. Telegram accepted
+# getUpdates), then confirm it stays up rather than crash-looping.
+started_at=$(docker inspect --format '{{.State.StartedAt}}' "$CONTAINER")
+restarts_before=$(docker inspect --format '{{.RestartCount}}' "$CONTAINER")
+
+log "waiting for evidence of live polling (timeout ${POLL_TIMEOUT}s)"
+polling=false
+for _ in $(seq 1 "$POLL_TIMEOUT"); do
+    if docker logs "$CONTAINER" --since "$started_at" 2>&1 | grep -q 'msg="bot polling"'; then
+        polling=true; break
+    fi
+    [[ "$(docker inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" != true ]] \
+        && { log "container exited before it reported polling"; break; }
+    sleep 1
+done
+[[ "$polling" == true ]] || rollback "$TAG never reported 'bot polling' (Telegram unreachable?)"
+
+# A crash-loop can still look healthy in snapshots, because each fresh start
+# re-opens the health port. Compare restart counts across a settle window.
+log "settling ${SETTLE_SECONDS}s to rule out a crash-loop"
+sleep "$SETTLE_SECONDS"
+restarts_after=$(docker inspect --format '{{.RestartCount}}' "$CONTAINER")
+running_now=$(docker inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null || echo false)
+
+[[ "$running_now" == true ]] || rollback "$TAG stopped running during the settle window"
+if [[ "$restarts_after" != "$restarts_before" ]]; then
+    rollback "$TAG is crash-looping (restart count $restarts_before -> $restarts_after)"
+fi
+if docker logs "$CONTAINER" --since "$started_at" 2>&1 | grep -qE 'panic: |level=FATAL'; then
+    rollback "$TAG panicked after starting"
+fi
+
+# Deliberately NOT a rollback trigger: a single level=ERROR right after start is
+# usually ordinary traffic (e.g. a send to a user who blocked the bot). Surfacing
+# it beats auto-reverting a good release on a benign error.
+errs=$(docker logs "$CONTAINER" --since "$started_at" 2>&1 | grep -c 'level=ERROR' || true)
+[[ "$errs" -gt 0 ]] && log "note: $errs level=ERROR line(s) since start — not treated as deploy failure"
+
+log "verified live: polling up, no crash-loop, no panic"
 
 # `:prod` stays a moving pointer at whatever is live, so CUTOVER.md's manual
 # commands and anything else referencing :prod keep working.


### PR DESCRIPTION
## The gap

A green deploy did **not** prove the bot was serving anyone.

The Docker healthcheck is a bare TCP connect to the health port, and `main.go` opens that listener **before** `Run()` calls `StartPolling`. So the container reports `healthy` before it has ever reached Telegram.

If polling then failed, `main` exits, the restart policy loops the container — and because **each fresh start re-opens the health port**, point-in-time checks keep looking fine. The deploy would already have been reported green while the bot was dead to users.

Realistic trigger: the proxy being down. `PROXY` is required in this environment, and Telegram is unreachable without it.

## What's added

After `healthy`, the deploy now demands positive evidence from *this* container start:

1. **The `bot polling` line** — only logged once `StartPolling` has returned, i.e. Telegram accepted `getUpdates`. Scoped to this start via `docker logs --since <StartedAt>`, so a previous run's line can't satisfy it.
2. **A 20s settle window**, then confirm the container is still running and its **restart count hasn't moved** — this is what catches a crash-loop that snapshots miss.
3. `panic:` / `level=FATAL` also roll back.

All four failure paths reuse one `rollback()` function (previous commit + previous image, no rebuild).

### One deliberate non-trigger

A lone `level=ERROR` does **not** roll back. Right after start that's usually ordinary traffic — a send to a user who has blocked the bot, for instance — and auto-reverting a good release on a benign error would be worse than surfacing it. Those lines are counted into the deploy log instead.

## Verification

Probes run against the **live production container** to confirm they match reality, not just my assumptions:

```
StartedAt=2026-08-03T08:37:06.247018678Z
RestartCount=0
polling-line match: 1
panic/fatal match (want 0): 0
level=ERROR count: 0
```

`shellcheck` clean, `bash -n` clean.

## Note on rollout

`deploy-tag.sh` runs from `/usr/local/bin/`, so merging this doesn't activate it — the running copy deploys the tag that *contains* the new copy. It needs a one-line reinstall on the server after merge (documented in `RELEASING.md`), which I'll do before cutting the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)