### PR TITLE
feat: report-channel actions, donation toggle, new contact links

### DIFF
--- a/Texts/admin.txt
+++ b/Texts/admin.txt
@@ -27,4 +27,10 @@
 <code>/admin ai-session set SESSION_ID</code>: set new AI session ID
 <code>/admin ai-session reset</code>: reset AI session ID to config default
 🔸---------------
+<code>/admin_donate</code>: show the donation button state and link
+<code>/admin_donate active</code>: show the donation button under messages
+<code>/admin_donate deactive</code>: hide it (default)
+<code>/admin_donate link URL</code>: set the donation link
+<code>/admin_donate link reset</code>: reset the link to config default
+🔸---------------
 <code>/admin backup</code>: send the last backup file

--- a/Texts/start_help.txt
+++ b/Texts/start_help.txt
@@ -22,6 +22,5 @@
 %s
 
 <blockquote expandable>ارتباط با ما:
-• t.me/ChevaletBotNews (کانال اخبار)
-• t.me/Chevalet_bot?start=Chevaletsupport (پشتیبانی)
-• t.me/Chevalet_bot?start=Programmer (برنامه‌نویس)</blockquote>
+• https://t.me/chevalet_studio (کانال اخبار)
+• https://t.me/chevalet_studio?direct (پشتیبانی و برنامه‌نویس)</blockquote>

--- a/internal/bot/admin.go
+++ b/internal/bot/admin.go
@@ -234,6 +234,9 @@ func (b *Bot) adminDispatch(tg *gotgbot.Bot, ctx *ext.Context, userid string, te
 			return errWrongSyntax
 		}
 
+	case "donate":
+		return b.adminDonate(ctx, text)
+
 	case "backup":
 		return b.adminBackup(tg, ctx)
 

--- a/internal/bot/admindonate.go
+++ b/internal/bot/admindonate.go
@@ -1,0 +1,151 @@
+package bot
+
+import (
+	"errors"
+	"html"
+	"strings"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+)
+
+// The donation button under delivered messages was removed by request, and this
+// is how an admin brings it back without a redeploy. Both the on/off flag and the
+// URL live in dynamic_settings.json (see internal/dynset), so a restart keeps
+// whatever was set.
+//
+// Reachable two ways on purpose: `/admin donate …` matches every other admin
+// sub-command, and `/admin_donate …` is the spelling that was asked for. They run
+// the same code.
+//
+//	/admin_donate                 -> show the current state
+//	/admin_donate active          -> show the button
+//	/admin_donate deactive        -> hide the button (the default)
+//	/admin_donate link <url>      -> set the donation URL
+//	/admin_donate link reset      -> go back to the configured DONATION_LINK
+
+// donateKind is what the admin asked for.
+type donateKind int
+
+const (
+	donateShow      donateKind = iota // no args: just report the state
+	donateToggle                      // active / deactive
+	donateSetLink                     // link <url>
+	donateResetLink                   // link reset
+)
+
+// donateAction is the parsed request. Keeping parsing separate from Telegram I/O
+// makes the accepted spellings and the URL rule unit-testable.
+type donateAction struct {
+	kind donateKind
+	on   bool   // for donateToggle
+	link string // for donateSetLink
+}
+
+// errBadDonateURL rejects a link Telegram would refuse as a URL button target.
+// This matters more than cosmetics: an invalid url makes EVERY delivered message
+// fail to send, so it must never reach the keyboard.
+var errBadDonateURL = errors.New("donation link must start with http:// or https://")
+
+// parseDonateArgs turns the admin's words into an action.
+//
+// "active"/"deactive" is the wording from the request; "activate"/"deactivate",
+// "enable"/"disable" and "on"/"off" are accepted too, because those are what
+// people actually type. A leading "donate" is dropped so /admin donate … and
+// /admin_donate … can share this.
+func parseDonateArgs(args []string) (donateAction, error) {
+	if len(args) > 0 && strings.EqualFold(args[0], "donate") {
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		return donateAction{kind: donateShow}, nil
+	}
+
+	switch strings.ToLower(args[0]) {
+	case "active", "activate", "enable", "on":
+		return donateAction{kind: donateToggle, on: true}, nil
+
+	case "deactive", "deactivate", "disable", "off":
+		return donateAction{kind: donateToggle, on: false}, nil
+
+	case "link", "set":
+		v, err := at(args, 1)
+		if err != nil {
+			return donateAction{}, err
+		}
+		if strings.EqualFold(v, "reset") {
+			return donateAction{kind: donateResetLink}, nil
+		}
+		if !strings.HasPrefix(v, "https://") && !strings.HasPrefix(v, "http://") {
+			return donateAction{}, errBadDonateURL
+		}
+		return donateAction{kind: donateSetLink, link: v}, nil
+
+	default:
+		return donateAction{}, errWrongSyntax
+	}
+}
+
+// adminDonate applies a parsed request and always replies with the resulting
+// state, so the admin sees what is live rather than only that something changed.
+func (b *Bot) adminDonate(ctx *ext.Context, args []string) error {
+	act, err := parseDonateArgs(args)
+	switch {
+	case errors.Is(err, errBadDonateURL):
+		return b.replyHTML(ctx, "the link must start with <code>https://</code> or <code>http://</code>.", false)
+	case err != nil:
+		return err // errWrongSyntax -> the caller's usage reply
+	}
+
+	switch act.kind {
+	case donateShow:
+		return b.replyHTML(ctx, b.donateStatus(), false)
+
+	case donateToggle:
+		b.Dyn.SetDonationEnabled(act.on)
+		head := "❌ donation button DEACTIVE."
+		if act.on {
+			head = "✅ donation button ACTIVE."
+		}
+		return b.replyHTML(ctx, head+"\n\n"+b.donateStatus(), false)
+
+	case donateSetLink:
+		b.Dyn.SetDonationLink(act.link)
+		return b.replyHTML(ctx, "donation link updated.\n\n"+b.donateStatus(), false)
+
+	case donateResetLink:
+		b.Dyn.ResetDonationLink()
+		return b.replyHTML(ctx, "donation link reset to the configured default.\n\n"+b.donateStatus(), false)
+	}
+	return errWrongSyntax
+}
+
+// donateStatus renders the current flag and URL.
+func (b *Bot) donateStatus() string {
+	state := "❌ deactive (button hidden)"
+	if b.Dyn.DonationEnabled() {
+		state = "✅ active (button shown)"
+	}
+	return "donation button: " + state +
+		"\nlink: <code>" + html.EscapeString(b.Dyn.DonationLink()) + "</code>" +
+		"\n\n<code>/admin_donate active|deactive</code>" +
+		"\n<code>/admin_donate link &lt;url&gt;</code>"
+}
+
+// adminDonateCmd backs the /admin_donate alias.
+func adminDonateCmd(b *Bot, _ *gotgbot.Bot, ctx *ext.Context, userid string) error {
+	if !b.isAdmin(userid) {
+		// Same as /admin: a non-admin must not learn the command exists.
+		return b.otherMessagesTemplate(ctx)
+	}
+	fields := strings.Fields(ctx.EffectiveMessage.Text)
+	if len(fields) > 0 {
+		fields = fields[1:] // drop "/admin_donate"
+	}
+	if err := b.adminDonate(ctx, fields); errors.Is(err, errWrongSyntax) {
+		return b.replyHTML(ctx, "wrong syntax.\n\n"+b.donateStatus(), false)
+	} else if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/bot/admindonate_test.go
+++ b/internal/bot/admindonate_test.go
@@ -1,0 +1,84 @@
+package bot
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestParseDonateArgs locks the /admin_donate grammar: which words toggle the
+// button, that a leading "donate" is dropped so /admin donate … and
+// /admin_donate … behave identically, and that a link Telegram would reject never
+// gets through (an invalid URL button makes every delivered message fail to send,
+// so this is the important case).
+func TestParseDonateArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want donateAction
+	}{
+		{"no args shows state", nil, donateAction{kind: donateShow}},
+		{"bare donate shows state", []string{"donate"}, donateAction{kind: donateShow}},
+
+		// The wording from the request, plus the spellings people reach for.
+		{"active", []string{"active"}, donateAction{kind: donateToggle, on: true}},
+		{"activate", []string{"activate"}, donateAction{kind: donateToggle, on: true}},
+		{"enable", []string{"enable"}, donateAction{kind: donateToggle, on: true}},
+		{"on", []string{"on"}, donateAction{kind: donateToggle, on: true}},
+		{"deactive", []string{"deactive"}, donateAction{kind: donateToggle, on: false}},
+		{"deactivate", []string{"deactivate"}, donateAction{kind: donateToggle, on: false}},
+		{"disable", []string{"disable"}, donateAction{kind: donateToggle, on: false}},
+		{"off", []string{"off"}, donateAction{kind: donateToggle, on: false}},
+
+		// Case-insensitive, and reachable through the /admin sub-command form.
+		{"uppercase", []string{"ACTIVE"}, donateAction{kind: donateToggle, on: true}},
+		{"via admin donate", []string{"donate", "deactive"}, donateAction{kind: donateToggle, on: false}},
+
+		{"set link", []string{"link", "https://x.example/pay"},
+			donateAction{kind: donateSetLink, link: "https://x.example/pay"}},
+		{"set link via set", []string{"set", "http://x.example"},
+			donateAction{kind: donateSetLink, link: "http://x.example"}},
+		{"reset link", []string{"link", "reset"}, donateAction{kind: donateResetLink}},
+		{"reset is case-insensitive", []string{"link", "RESET"}, donateAction{kind: donateResetLink}},
+		{"via admin donate link", []string{"donate", "link", "https://y.example"},
+			donateAction{kind: donateSetLink, link: "https://y.example"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseDonateArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parseDonateArgs(%q) err = %v; want nil", tc.args, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseDonateArgs(%q) = %+v; want %+v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseDonateArgsRejects(t *testing.T) {
+	// A link that is not http(s) must be refused, not stored: Telegram rejects the
+	// keyboard outright, which would break sending for everyone.
+	for _, bad := range []string{
+		"donate.example/pay", // no scheme
+		"tg://resolve?domain=x",
+		"javascript:alert(1)",
+		"ftp://x.example",
+		"'; DROP TABLE users;--",
+	} {
+		if _, err := parseDonateArgs([]string{"link", bad}); !errors.Is(err, errBadDonateURL) {
+			t.Errorf("parseDonateArgs(link %q) err = %v; want errBadDonateURL", bad, err)
+		}
+	}
+
+	// Unknown verbs and a missing url are syntax errors.
+	for _, args := range [][]string{
+		{"maybe"},
+		{"activee"},
+		{"link"},           // no url
+		{"set"},            // no url
+		{"donate", "link"}, // no url via the /admin form
+	} {
+		if _, err := parseDonateArgs(args); !errors.Is(err, errWrongSyntax) {
+			t.Errorf("parseDonateArgs(%q) err = %v; want errWrongSyntax", args, err)
+		}
+	}
+}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -135,7 +135,7 @@ func New(cfg *config.Config, database *db.DB, txt *texts.Loader) (*Bot, error) {
 		DB:         database,
 		Cfg:        cfg,
 		Texts:      txt,
-		Dyn:        dynset.New("dynamic_settings.json", cfg.AIURL, cfg.AISessionID),
+		Dyn:        dynset.New("dynamic_settings.json", cfg.AIURL, cfg.AISessionID, cfg.DonationLink),
 		Tokens:     tokens,
 		users:      newUserStore(),
 		aiQueue:    newAIQueue(),

--- a/internal/bot/callbacks.go
+++ b/internal/bot/callbacks.go
@@ -355,7 +355,19 @@ func reportConfirmYes(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) 
 		"reported: " + b.getLinkUsername(targetUID) + "\n" +
 		"\n----------------\n❇️ COPY: <code>" + targetUID + "</code>\n------------\n" +
 		"message:"
-	firstMessage, err := tg.SendMessage(reportChatID, header, &gotgbot.SendMessageOpts{ParseMode: "HTML"})
+	// Action buttons so an admin can register the report, ban, or write to either
+	// party from the channel instead of copying the uid into /admin commands.
+	// Sealing can only fail if the token cipher has no key, which bot.New already
+	// refuses to start without; on the impossible path, post the report anyway
+	// (losing the buttons) rather than lose the report itself.
+	reporterToken, rerr := b.Tokens.Seal(userID64, nil)
+	reportedToken, derr := b.Tokens.Seal(targetID, nil)
+	headerOpts := &gotgbot.SendMessageOpts{ParseMode: "HTML"}
+	if rerr == nil && derr == nil {
+		kb := reportActionKeyboard(reporterToken, reportedToken)
+		headerOpts.ReplyMarkup = kb
+	}
+	firstMessage, err := tg.SendMessage(reportChatID, header, headerOpts)
 	if err != nil {
 		return err
 	}

--- a/internal/bot/handlers.go
+++ b/internal/bot/handlers.go
@@ -30,6 +30,15 @@ func (b *Bot) registerHandlers() {
 	// the conversation so it is never shadowed.
 	d.AddHandler(handlers.NewCallback(cqfilters.Prefix("errmore|"), b.errMore))
 
+	// report action buttons — the accept/ban/message buttons under reports in
+	// REPORT_CHAT_ID. Also OUTSIDE prep: that chat is a channel, which prep drops.
+	d.AddHandler(handlers.NewCallback(cqfilters.Prefix("rpt|"), b.reportAction))
+
+	// An admin's reply to a "write the message" prompt, in their own private chat.
+	// Ahead of the conversations so the reply is not consumed as an anonymous
+	// message; the filter only matches replies to the bot's own prompt.
+	d.AddHandler(handlers.NewMessage(b.rptComposeFilter(botIDInt(b.Cfg.BotID)), b.topLevel(rptComposeReply)))
+
 	// no_callback_handler — answers the spacer / "sent with link" buttons.
 	d.AddHandler(handlers.NewCallback(cqfilters.Prefix("no-callback"), b.topLevel(noCallback)))
 

--- a/internal/bot/handlers.go
+++ b/internal/bot/handlers.go
@@ -54,6 +54,7 @@ func (b *Bot) registerHandlers() {
 	b.command("privacy", cmdPrivacy)
 	b.command("donate", cmdDonate)
 	b.command("admin", adminCmd)
+	b.command("admin_donate", adminDonateCmd)
 	b.command("myuid", cmdMyUID)
 	b.command("bug", cmdBug)
 
@@ -241,7 +242,10 @@ func cmdHelp(b *Bot, _ *gotgbot.Bot, ctx *ext.Context, _ string) error {
 	if err != nil {
 		return err
 	}
-	txt = strings.ReplaceAll(txt, "%s", b.Cfg.DonationLink)
+	// b.Dyn, not b.Cfg: an admin who changes the donation link with /admin_donate
+	// must change it everywhere it appears, otherwise the button and the texts
+	// would point at two different places.
+	txt = strings.ReplaceAll(txt, "%s", b.Dyn.DonationLink())
 	return b.replyHTML(ctx, txt, true)
 }
 
@@ -263,7 +267,7 @@ func cmdDonate(b *Bot, _ *gotgbot.Bot, ctx *ext.Context, _ string) error {
 	if err != nil {
 		return err
 	}
-	txt = strings.ReplaceAll(txt, "%s", b.Cfg.DonationLink)
+	txt = strings.ReplaceAll(txt, "%s", b.Dyn.DonationLink())
 	return b.replyHTML(ctx, txt, false)
 }
 

--- a/internal/bot/markup.go
+++ b/internal/bot/markup.go
@@ -68,15 +68,18 @@ func messageKeyboard(tokenMid, tokenBlock string, mid int64, seen bool) [][]gotg
 	return [][]gotgbot.InlineKeyboardButton{
 		firstRow,
 		{
+			// The Python original put a blank " " button between these two as a
+			// spacer. Removed by request: it did nothing, and Telegram spreads the
+			// two real buttons across the row anyway.
 			cb(msgBtnReport, "report|"+tokenMid+"|"+midStr),
-			cb(" ", "no-callback"),
 			cb(msgBtnBlock, "block|"+tokenBlock),
 		},
 	}
 }
 
 // donationRow mirrors the trailing donation-link button row appended to every
-// delivered message's keyboard.
+// delivered message's keyboard. Only appended when an admin has enabled it
+// (/admin_donate active) — it is off by default.
 func donationRow(donationLink string) []gotgbot.InlineKeyboardButton {
 	return []gotgbot.InlineKeyboardButton{urlBtn(btnDonation, donationLink)}
 }

--- a/internal/bot/markup_test.go
+++ b/internal/bot/markup_test.go
@@ -12,7 +12,9 @@ func TestMessageKeyboard(t *testing.T) {
 	const tokenBlock = "TOKBLK"
 	const mid int64 = 12345
 
-	// without "seen": row0 = [answer], row1 = [report, spacer, block].
+	// without "seen": row0 = [answer], row1 = [report, block].
+	// The blank spacer button that used to sit between report and block was
+	// removed by request, so row1 is 2 buttons — see messageKeyboard.
 	kb := messageKeyboard(tokenMid, tokenBlock, mid, false)
 	if len(kb) != 2 {
 		t.Fatalf("rows = %d; want 2", len(kb))
@@ -23,20 +25,23 @@ func TestMessageKeyboard(t *testing.T) {
 	if kb[0][0].CallbackData != "answer|TOKMID|12345" {
 		t.Errorf("answer data = %q; want answer|TOKMID|12345", kb[0][0].CallbackData)
 	}
-	if len(kb[1]) != 3 {
-		t.Fatalf("row1 buttons = %d; want 3 (report, spacer, block)", len(kb[1]))
+	if len(kb[1]) != 2 {
+		t.Fatalf("row1 buttons = %d; want 2 (report, block)", len(kb[1]))
 	}
 	if kb[1][0].CallbackData != "report|TOKMID|12345" {
 		t.Errorf("report data = %q; want report|TOKMID|12345", kb[1][0].CallbackData)
 	}
-	if kb[1][1].CallbackData != "no-callback" {
-		t.Errorf("spacer data = %q; want no-callback", kb[1][1].CallbackData)
+	// No button in the row may be the old blank spacer.
+	for i, btn := range kb[1] {
+		if btn.CallbackData == "no-callback" {
+			t.Errorf("row1[%d] is still the removed spacer button", i)
+		}
 	}
 	// block carries the SEPARATE block token and NO mid — blocking a sender, not a
 	// message. It must never carry the mid-bound token (that token is the S-0001
 	// binding for the id-acting verbs).
-	if kb[1][2].CallbackData != "block|TOKBLK" {
-		t.Errorf("block data = %q; want block|TOKBLK (separate token, no mid)", kb[1][2].CallbackData)
+	if kb[1][1].CallbackData != "block|TOKBLK" {
+		t.Errorf("block data = %q; want block|TOKBLK (separate token, no mid)", kb[1][1].CallbackData)
 	}
 
 	// with "seen": the seen button is inserted at the FRONT of row0.

--- a/internal/bot/reportactions.go
+++ b/internal/bot/reportactions.go
@@ -44,6 +44,11 @@ const (
 	rptVerbBan         = "b"
 	rptVerbMsgReporter = "mr"
 	rptVerbMsgReported = "md"
+	// rptVerbDone is the spent accept/ban row. It carries no token and does
+	// nothing, but it must still be answered: the generic no-callback handler runs
+	// under prep, which drops channel updates, so a tap there would leave the
+	// client spinning until it timed out.
+	rptVerbDone = "x"
 )
 
 // composeMarker tags the prompt the bot sends to an admin's private chat. The
@@ -75,7 +80,7 @@ func reportActionKeyboard(reporterToken, reportedToken string) gotgbot.InlineKey
 // second admin cannot double-ban or double-count the same report, and so the log
 // of who handled it survives in the channel.
 func rptDoneRow(label string) []gotgbot.InlineKeyboardButton {
-	return row(cb(label, "no-callback"))
+	return row(cb(label, "rpt|"+rptVerbDone+"|-"))
 }
 
 // adminLabel is a short human name for the admin who tapped, for the done label.
@@ -120,6 +125,15 @@ func (b *Bot) reportAction(tg *gotgbot.Bot, ctx *ext.Context) error {
 		return nil
 	}
 	verb, token := fields[1], fields[2]
+
+	// The spent status button: acknowledge and stop, before any token handling —
+	// it deliberately carries no token.
+	if verb == rptVerbDone {
+		_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+			Text: "این ریپورت قبلا بررسی شده.",
+		})
+		return nil
+	}
 
 	uid, ok := b.Tokens.Open(token, nil)
 	if !ok {

--- a/internal/bot/reportactions.go
+++ b/internal/bot/reportactions.go
@@ -1,0 +1,350 @@
+package bot
+
+import (
+	"html"
+	"strconv"
+	"strings"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers/filters"
+	msgfilters "github.com/PaulSonOfLars/gotgbot/v2/ext/handlers/filters/message"
+)
+
+// Action buttons under every report posted to REPORT_CHAT_ID.
+//
+// Before this, an admin read the report, copied the uid out of the header, and
+// ran /admin report add … or /admin ban … by hand. These four buttons do the same
+// work in one tap, and add the ability to write to either party through the bot:
+//
+//	[ ✅ register report ] [ 🚫 ban ]
+//	[ ✉️ message reporter ] [ ✉️ message reported ]
+//
+// Three things about the environment shape this code:
+//
+//  1. REPORT_CHAT_ID is a CHANNEL, and prep deliberately drops channel updates
+//     (decorators.py parity), so the callback handler is registered outside prep —
+//     the same exception errMore makes for the error chat.
+//  2. In a channel the callback's From is the admin who tapped, which is what the
+//     admin check and the "who did it" label use. It is checked against ADMINS
+//     server-side; being able to see the channel is not authority to ban.
+//  3. Composing a message cannot happen in the channel (that would show the draft
+//     to everyone), so the bot asks in the admin's private chat instead.
+const (
+	btnRptAccept      = "✅ ثبت ریپورت"
+	btnRptBan         = "🚫 بن کردن"
+	btnRptMsgReporter = "✉️ پیام به ریپورت‌کننده"
+	btnRptMsgReported = "✉️ پیام به ریپورت‌شده"
+)
+
+// Callback verbs. Kept to two characters because callback_data is capped at 64
+// bytes and each carries a 31-char sealed token: "rpt|md|" + 31 = 38.
+const (
+	rptVerbAccept      = "a"
+	rptVerbBan         = "b"
+	rptVerbMsgReporter = "mr"
+	rptVerbMsgReported = "md"
+)
+
+// composeMarker tags the prompt the bot sends to an admin's private chat. The
+// admin's reply is matched by looking at the message it replies TO, so the pending
+// compose survives a bot restart — there is no in-memory state to lose. The token
+// after the marker is the sealed target uid, so a raw id never appears even here.
+const composeMarker = "ref:rpt:"
+
+// reportActionKeyboard is attached to the report header message.
+//
+// Sealed tokens rather than raw uids: the header already prints the reported uid
+// for copy/paste, so this is not hiding anything from admins — it keeps the
+// invariant that no real Telegram id is ever put in callback_data, which is what
+// stops an id leaking if a button is ever surfaced somewhere less private.
+func reportActionKeyboard(reporterToken, reportedToken string) gotgbot.InlineKeyboardMarkup {
+	return ikb(
+		row(
+			cb(btnRptAccept, "rpt|"+rptVerbAccept+"|"+reportedToken),
+			cb(btnRptBan, "rpt|"+rptVerbBan+"|"+reportedToken),
+		),
+		row(
+			cb(btnRptMsgReporter, "rpt|"+rptVerbMsgReporter+"|"+reporterToken),
+			cb(btnRptMsgReported, "rpt|"+rptVerbMsgReported+"|"+reportedToken),
+		),
+	)
+}
+
+// rptDoneRow replaces the accept/ban row once one of them has been used, so a
+// second admin cannot double-ban or double-count the same report, and so the log
+// of who handled it survives in the channel.
+func rptDoneRow(label string) []gotgbot.InlineKeyboardButton {
+	return row(cb(label, "no-callback"))
+}
+
+// adminLabel is a short human name for the admin who tapped, for the done label.
+func adminLabel(u gotgbot.User) string {
+	if u.Username != "" {
+		return "@" + u.Username
+	}
+	if u.FirstName != "" {
+		return u.FirstName
+	}
+	return strconv.FormatInt(u.Id, 10)
+}
+
+// reportAction handles the four buttons. Registered OUTSIDE prep (channel chat).
+func (b *Bot) reportAction(tg *gotgbot.Bot, ctx *ext.Context) error {
+	clbk := ctx.CallbackQuery
+	if clbk == nil || clbk.Data == "" {
+		return nil
+	}
+	msg := ctx.EffectiveMessage
+
+	// Only ever act inside the configured report chat.
+	if msg == nil || b.Cfg.ReportChatID == "" ||
+		strconv.FormatInt(msg.Chat.Id, 10) != b.Cfg.ReportChatID {
+		_, _ = clbk.Answer(tg, nil)
+		return nil
+	}
+
+	// Authority comes from ADMINS, not from channel membership.
+	actor := strconv.FormatInt(clbk.From.Id, 10)
+	if !b.isAdmin(actor) {
+		_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+			Text:      "فقط ادمین‌ها می‌تونن از این دکمه‌ها استفاده کنن.",
+			ShowAlert: true,
+		})
+		return nil
+	}
+
+	fields := strings.SplitN(clbk.Data, "|", 3)
+	if len(fields) != 3 {
+		_, _ = clbk.Answer(tg, nil)
+		return nil
+	}
+	verb, token := fields[1], fields[2]
+
+	uid, ok := b.Tokens.Open(token, nil)
+	if !ok {
+		_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+			Text:      "این دکمه دیگه معتبر نیست.",
+			ShowAlert: true,
+		})
+		return nil
+	}
+	uidStr := strconv.FormatInt(uid, 10)
+
+	switch verb {
+	case rptVerbAccept:
+		return b.rptAccept(tg, ctx, clbk, uidStr)
+	case rptVerbBan:
+		return b.rptBan(tg, ctx, clbk, uidStr)
+	case rptVerbMsgReporter:
+		return b.rptAskCompose(tg, clbk, token, "reporter")
+	case rptVerbMsgReported:
+		return b.rptAskCompose(tg, clbk, token, "reported")
+	default:
+		_, _ = clbk.Answer(tg, nil)
+		return nil
+	}
+}
+
+// rptAccept records one report against the reported user, exactly as
+// `/admin report add <uid>` did by hand, and reports the new total.
+func (b *Bot) rptAccept(tg *gotgbot.Bot, ctx *ext.Context, clbk *gotgbot.CallbackQuery, uid string) error {
+	dbctx, cancel := b.bg()
+	defer cancel()
+
+	count, err := b.DB.AddReportID(dbctx, uid)
+	if err != nil {
+		return err
+	}
+	_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+		Text:      "ثبت شد. تعداد ریپورت‌های این کاربر: " + strconv.Itoa(count),
+		ShowAlert: true,
+	})
+	b.rptMarkDone(tg, ctx, "✅ ثبت شد ("+strconv.Itoa(count)+") — "+adminLabel(clbk.From))
+	return nil
+}
+
+// rptBan bans the reported user and tells them, which is the one notification the
+// bot sends here: they would discover it anyway the moment the bot stops
+// answering, so saying it plainly is clearer than going silent. Accepting a report
+// stays silent on purpose — a warning mostly invites a fresh account.
+func (b *Bot) rptBan(tg *gotgbot.Bot, ctx *ext.Context, clbk *gotgbot.CallbackQuery, uid string) error {
+	dbctx, cancel := b.bg()
+	defer cancel()
+
+	if err := b.DB.BanAction(dbctx, uid, true); err != nil {
+		return err
+	}
+	_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+		Text:      "کاربر بن شد.",
+		ShowAlert: true,
+	})
+
+	// Best effort: a user who never started the bot, or who blocked it, cannot be
+	// told — that must not fail the ban, which is already committed.
+	if uid64, perr := strconv.ParseInt(uid, 10, 64); perr == nil {
+		_, _ = tg.SendMessage(uid64, txtBannedNotice, &gotgbot.SendMessageOpts{ParseMode: "HTML"})
+	}
+	b.rptMarkDone(tg, ctx, "🚫 بن شد — "+adminLabel(clbk.From))
+	return nil
+}
+
+// rptMarkDone swaps the accept/ban row for a dead status button, leaving the two
+// message buttons usable (writing to either party still makes sense afterwards).
+func (b *Bot) rptMarkDone(tg *gotgbot.Bot, ctx *ext.Context, label string) {
+	msg := ctx.EffectiveMessage
+	if msg == nil || msg.ReplyMarkup == nil {
+		return
+	}
+	rows := msg.ReplyMarkup.InlineKeyboard
+	newRows := make([][]gotgbot.InlineKeyboardButton, 0, len(rows))
+	for _, r := range rows {
+		if rowHasVerb(r, rptVerbAccept) || rowHasVerb(r, rptVerbBan) {
+			newRows = append(newRows, rptDoneRow(label))
+			continue
+		}
+		newRows = append(newRows, r)
+	}
+	// Errors ignored deliberately: the action already succeeded, and Telegram
+	// rejects an unchanged markup — see tgerr.go's "message is not modified".
+	_, _, _ = msg.EditReplyMarkup(tg, &gotgbot.EditMessageReplyMarkupOpts{
+		ReplyMarkup: gotgbot.InlineKeyboardMarkup{InlineKeyboard: newRows},
+	})
+}
+
+// rowHasVerb reports whether a keyboard row carries one of the rpt verbs.
+func rowHasVerb(r []gotgbot.InlineKeyboardButton, verb string) bool {
+	for _, btn := range r {
+		if strings.HasPrefix(btn.CallbackData, "rpt|"+verb+"|") {
+			return true
+		}
+	}
+	return false
+}
+
+// rptAskCompose asks the admin, in their own private chat, for the text to send.
+//
+// It has to be private: a draft typed into the report channel would be visible to
+// everyone there. The prompt carries the sealed target uid, and the admin's reply
+// is matched against the prompt, so nothing needs to be remembered in memory and
+// a restart mid-compose is harmless.
+func (b *Bot) rptAskCompose(tg *gotgbot.Bot, clbk *gotgbot.CallbackQuery, token, role string) error {
+	who := "ریپورت‌کننده"
+	if role == "reported" {
+		who = "کاربر ریپورت‌شده"
+	}
+
+	prompt := "✉️ <b>ارسال پیام به " + who + "</b>\n\n" +
+		"متن پیام رو در جواب همین پیام بنویس. پیام با اسم بات براش فرستاده میشه.\n" +
+		"برای انصراف /cancel رو بفرست.\n\n" +
+		"<code>" + composeMarker + role + ":" + token + "</code>"
+
+	_, err := tg.SendMessage(clbk.From.Id, prompt, &gotgbot.SendMessageOpts{
+		ParseMode:   "HTML",
+		ReplyMarkup: gotgbot.ForceReply{ForceReply: true, InputFieldPlaceholder: "متن پیام…"},
+	})
+	if err != nil {
+		// Almost always "bot can't initiate conversation with a user": the admin
+		// has never opened a private chat with the bot.
+		_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+			Text:      "نشد برات پیام خصوصی بفرستم. اول یه /start به بات بده بعد دوباره امتحان کن.",
+			ShowAlert: true,
+		})
+		return nil
+	}
+	_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+		Text:      "توی چت خصوصی بات، متن پیام رو بنویس.",
+		ShowAlert: true,
+	})
+	return nil
+}
+
+// rptComposeFilter matches an admin's reply to a compose prompt: a private text
+// message replying to a bot message that carries the marker. Narrow on purpose —
+// it is registered ahead of the conversations, so it must not match anything else.
+func (b *Bot) rptComposeFilter(botID int64) filters.Message {
+	return func(m *gotgbot.Message) bool {
+		return m.Chat.Type == "private" &&
+			msgfilters.Text(m) &&
+			m.ReplyToMessage != nil &&
+			m.ReplyToMessage.From != nil &&
+			m.ReplyToMessage.From.Id == botID &&
+			strings.Contains(m.ReplyToMessage.Text, composeMarker)
+	}
+}
+
+// rptComposeReply delivers what the admin wrote to the party the prompt names.
+func rptComposeReply(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error {
+	msg := ctx.EffectiveMessage
+	if msg == nil || msg.ReplyToMessage == nil {
+		return nil
+	}
+	// Re-check authority: the prompt is old and the admin list may have changed.
+	if !b.isAdmin(userid) {
+		return nil
+	}
+	if strings.TrimSpace(msg.Text) == "/cancel" {
+		return b.replyText(ctx, "لغو شد.")
+	}
+
+	role, token, ok := parseComposeRef(msg.ReplyToMessage.Text)
+	if !ok {
+		return nil
+	}
+	uid, ok := b.Tokens.Open(token, nil)
+	if !ok {
+		return b.replyText(ctx, "این درخواست دیگه معتبر نیست.")
+	}
+
+	body := "📩 <b>پیام از طرف پشتیبانی</b>\n\n" + html.EscapeString(msg.Text)
+	if _, err := tg.SendMessage(uid, body, &gotgbot.SendMessageOpts{ParseMode: "HTML"}); err != nil {
+		// A user who blocked the bot or never started it is an expected outcome
+		// here, not a bug worth an error report.
+		return b.replyText(ctx, "نشد پیام رو بفرستم — احتمالا کاربر بات رو بلاک کرده یا هیچوقت استارت نزده.")
+	}
+
+	who := "ریپورت‌کننده"
+	if role == "reported" {
+		who = "کاربر ریپورت‌شده"
+	}
+	return b.replyText(ctx, "✅ پیام برای "+who+" فرستاده شد.")
+}
+
+// parseComposeRef pulls the role and sealed token back out of a prompt.
+//
+// The token is cut at the first character that cannot appear in base64url rather
+// than at whitespace. Telegram strips HTML from Message.Text (the tags arrive as
+// entities), so in practice the marker ends the text cleanly — but if that ever
+// stopped holding, a trailing "</code>" would ride along inside the token, Open
+// would fail, and the compose flow would break silently. Cutting on the charset
+// makes the parser independent of that assumption.
+func parseComposeRef(promptText string) (role, token string, ok bool) {
+	i := strings.Index(promptText, composeMarker)
+	if i < 0 {
+		return "", "", false
+	}
+	rest := promptText[i+len(composeMarker):]
+
+	role, rest, found := strings.Cut(rest, ":")
+	if !found || (role != "reporter" && role != "reported") {
+		return "", "", false
+	}
+	end := len(rest)
+	for j := 0; j < len(rest); j++ {
+		if !isBase64URLChar(rest[j]) {
+			end = j
+			break
+		}
+	}
+	token = rest[:end]
+	if token == "" {
+		return "", "", false
+	}
+	return role, token, true
+}
+
+// isBase64URLChar reports whether c can appear in a RawURLEncoding token.
+func isBase64URLChar(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9') || c == '-' || c == '_'
+}

--- a/internal/bot/reportactions_test.go
+++ b/internal/bot/reportactions_test.go
@@ -89,8 +89,11 @@ func TestRptMarkDoneReplacesOnlyActionRow(t *testing.T) {
 	if len(newRows) != 2 {
 		t.Fatalf("rows after mark-done = %d; want 2", len(newRows))
 	}
-	if len(newRows[0]) != 1 || newRows[0][0].CallbackData != "no-callback" {
-		t.Errorf("action row was not replaced by a dead status button: %+v", newRows[0])
+	// The status button must route to the rpt| handler, not the generic
+	// no-callback one: that handler runs under prep, which drops channel updates,
+	// so a tap in the report channel would never be answered.
+	if len(newRows[0]) != 1 || newRows[0][0].CallbackData != "rpt|"+rptVerbDone+"|-" {
+		t.Errorf("action row was not replaced by an answerable status button: %+v", newRows[0])
 	}
 	if !strings.Contains(newRows[0][0].Text, "@someadmin") {
 		t.Errorf("status button %q does not name the admin who acted", newRows[0][0].Text)
@@ -100,7 +103,7 @@ func TestRptMarkDoneReplacesOnlyActionRow(t *testing.T) {
 		t.Fatalf("message row buttons = %d; want 2 (still usable)", len(newRows[1]))
 	}
 	for _, btn := range newRows[1] {
-		if btn.CallbackData == "no-callback" {
+		if strings.HasPrefix(btn.CallbackData, "rpt|"+rptVerbDone+"|") {
 			t.Errorf("message button %q was disabled; it should stay usable", btn.Text)
 		}
 	}

--- a/internal/bot/reportactions_test.go
+++ b/internal/bot/reportactions_test.go
@@ -1,0 +1,226 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+
+	"github.com/aturzone/chevaletAnonBot/internal/encoder"
+)
+
+// TestReportActionKeyboardShape locks the 4-button layout and, more importantly,
+// that every callback_data fits Telegram's 64-byte cap. A token is 31 chars, so
+// there is room — but a longer verb or an extra field would silently make
+// Telegram reject the whole keyboard, and the report would post without buttons.
+func TestReportActionKeyboardShape(t *testing.T) {
+	tc := encoder.NewTokenCipher("test-bot-token")
+	reporterTok, err := tc.Seal(1000000001, nil)
+	if err != nil {
+		t.Fatalf("Seal reporter: %v", err)
+	}
+	reportedTok, err := tc.Seal(1000000002, nil)
+	if err != nil {
+		t.Fatalf("Seal reported: %v", err)
+	}
+
+	kb := reportActionKeyboard(reporterTok, reportedTok)
+	if len(kb.InlineKeyboard) != 2 {
+		t.Fatalf("rows = %d; want 2", len(kb.InlineKeyboard))
+	}
+	for i, r := range kb.InlineKeyboard {
+		if len(r) != 2 {
+			t.Fatalf("row%d buttons = %d; want 2", i, len(r))
+		}
+	}
+
+	for _, r := range kb.InlineKeyboard {
+		for _, btn := range r {
+			if len(btn.CallbackData) > 64 {
+				t.Errorf("callback_data %q is %d bytes (>64, Telegram rejects it)",
+					btn.CallbackData, len(btn.CallbackData))
+			}
+			if !strings.HasPrefix(btn.CallbackData, "rpt|") {
+				t.Errorf("callback_data %q lacks the rpt| prefix the handler matches", btn.CallbackData)
+			}
+			// No raw Telegram id may appear: that is the whole point of sealing.
+			for _, raw := range []string{"1000000001", "1000000002"} {
+				if strings.Contains(btn.CallbackData, raw) {
+					t.Errorf("callback_data %q leaks a raw uid", btn.CallbackData)
+				}
+			}
+		}
+	}
+
+	// accept and ban must act on the REPORTED user; the reporter must never be the
+	// one banned by a mis-wired button.
+	accept, ban := kb.InlineKeyboard[0][0], kb.InlineKeyboard[0][1]
+	if accept.CallbackData != "rpt|"+rptVerbAccept+"|"+reportedTok {
+		t.Errorf("accept targets %q; want the reported token", accept.CallbackData)
+	}
+	if ban.CallbackData != "rpt|"+rptVerbBan+"|"+reportedTok {
+		t.Errorf("ban targets %q; want the reported token", ban.CallbackData)
+	}
+	msgReporter, msgReported := kb.InlineKeyboard[1][0], kb.InlineKeyboard[1][1]
+	if msgReporter.CallbackData != "rpt|"+rptVerbMsgReporter+"|"+reporterTok {
+		t.Errorf("message-reporter targets %q; want the reporter token", msgReporter.CallbackData)
+	}
+	if msgReported.CallbackData != "rpt|"+rptVerbMsgReported+"|"+reportedTok {
+		t.Errorf("message-reported targets %q; want the reported token", msgReported.CallbackData)
+	}
+}
+
+// TestRptMarkDoneReplacesOnlyActionRow proves the "who did it" swap kills the
+// accept/ban row (so two admins cannot both ban) while leaving the two message
+// buttons alive.
+func TestRptMarkDoneReplacesOnlyActionRow(t *testing.T) {
+	kb := reportActionKeyboard("TOKREPORTER", "TOKREPORTED")
+	rows := kb.InlineKeyboard
+
+	newRows := make([][]gotgbot.InlineKeyboardButton, 0, len(rows))
+	for _, r := range rows {
+		if rowHasVerb(r, rptVerbAccept) || rowHasVerb(r, rptVerbBan) {
+			newRows = append(newRows, rptDoneRow("🚫 بن شد — @someadmin"))
+			continue
+		}
+		newRows = append(newRows, r)
+	}
+
+	if len(newRows) != 2 {
+		t.Fatalf("rows after mark-done = %d; want 2", len(newRows))
+	}
+	if len(newRows[0]) != 1 || newRows[0][0].CallbackData != "no-callback" {
+		t.Errorf("action row was not replaced by a dead status button: %+v", newRows[0])
+	}
+	if !strings.Contains(newRows[0][0].Text, "@someadmin") {
+		t.Errorf("status button %q does not name the admin who acted", newRows[0][0].Text)
+	}
+	// The message buttons must still work afterwards.
+	if len(newRows[1]) != 2 {
+		t.Fatalf("message row buttons = %d; want 2 (still usable)", len(newRows[1]))
+	}
+	for _, btn := range newRows[1] {
+		if btn.CallbackData == "no-callback" {
+			t.Errorf("message button %q was disabled; it should stay usable", btn.Text)
+		}
+	}
+}
+
+// TestRowHasVerb guards the row matcher against matching a verb that merely
+// appears inside a token (a sealed token is arbitrary base64url text).
+func TestRowHasVerb(t *testing.T) {
+	r := row(cb("x", "rpt|a|TOKEN"), cb("y", "rpt|b|TOKEN"))
+	if !rowHasVerb(r, rptVerbAccept) {
+		t.Error("rowHasVerb(accept) = false; want true")
+	}
+	if !rowHasVerb(r, rptVerbBan) {
+		t.Error("rowHasVerb(ban) = false; want true")
+	}
+	if rowHasVerb(r, rptVerbMsgReporter) {
+		t.Error("rowHasVerb(msg-reporter) = true; want false")
+	}
+	// A token containing the verb letters must not count as that verb.
+	r2 := row(cb("x", "rpt|"+rptVerbMsgReported+"|aXbXmrXmd"))
+	if rowHasVerb(r2, rptVerbAccept) || rowHasVerb(r2, rptVerbBan) {
+		t.Error("a verb-like substring inside the token was matched as a verb")
+	}
+	if !rowHasVerb(r2, rptVerbMsgReported) {
+		t.Error("rowHasVerb did not match the real verb")
+	}
+}
+
+// TestParseComposeRef covers recovering the target from the prompt the admin
+// replies to. This is what makes the compose flow stateless: get it wrong and a
+// reply either goes nowhere or, worse, to the wrong person.
+func TestParseComposeRef(t *testing.T) {
+	tok := "abcdefghijklmnopqrstuvwxyz01234"
+
+	for _, tc := range []struct {
+		name, prompt, wantRole, wantTok string
+	}{
+		{"reporter", "bla bla\n<code>" + composeMarker + "reporter:" + tok + "</code>", "reporter", tok},
+		{"reported", "bla bla\n<code>" + composeMarker + "reported:" + tok + "</code>", "reported", tok},
+		{"marker at end without tags", composeMarker + "reporter:" + tok, "reporter", tok},
+		{"trailing text is not eaten", composeMarker + "reported:" + tok + " and more words", "reported", tok},
+		{"trailing newline", composeMarker + "reporter:" + tok + "\nnext line", "reporter", tok},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			role, got, ok := parseComposeRef(tc.prompt)
+			if !ok {
+				t.Fatalf("parseComposeRef(%q) not ok", tc.prompt)
+			}
+			if role != tc.wantRole {
+				t.Errorf("role = %q; want %q", role, tc.wantRole)
+			}
+			if got != tc.wantTok {
+				t.Errorf("token = %q; want %q", got, tc.wantTok)
+			}
+		})
+	}
+
+	// Anything malformed must be refused rather than guessed at.
+	for _, bad := range []string{
+		"",
+		"a normal message with no marker",
+		composeMarker,                         // nothing after it
+		composeMarker + "reporter",            // no token
+		composeMarker + "reporter:",           // empty token
+		composeMarker + "somebodyelse:" + tok, // unknown role
+		composeMarker + ":" + tok,             // empty role
+	} {
+		if role, tk, ok := parseComposeRef(bad); ok {
+			t.Errorf("parseComposeRef(%q) = (%q,%q,true); want not ok", bad, role, tk)
+		}
+	}
+}
+
+// TestComposePromptIsParseable ties the two halves together: the exact prompt the
+// bot sends must be readable back by the parser. Building the prompt and parsing
+// it live in different functions, so this is the seam that could drift.
+func TestComposePromptIsParseable(t *testing.T) {
+	tc := encoder.NewTokenCipher("test-bot-token")
+	const uid int64 = 1000000009
+	tok, err := tc.Seal(uid, nil)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	for _, role := range []string{"reporter", "reported"} {
+		who := "ریپورت‌کننده"
+		if role == "reported" {
+			who = "کاربر ریپورت‌شده"
+		}
+		// Mirrors rptAskCompose's prompt.
+		prompt := "✉️ <b>ارسال پیام به " + who + "</b>\n\n" +
+			"متن پیام رو در جواب همین پیام بنویس. پیام با اسم بات براش فرستاده میشه.\n" +
+			"برای انصراف /cancel رو بفرست.\n\n" +
+			"<code>" + composeMarker + role + ":" + tok + "</code>"
+
+		gotRole, gotTok, ok := parseComposeRef(prompt)
+		if !ok {
+			t.Fatalf("role %s: the bot's own prompt did not parse", role)
+		}
+		if gotRole != role {
+			t.Errorf("role = %q; want %q", gotRole, role)
+		}
+		// And the token must still open to the original uid.
+		gotUID, ok := tc.Open(gotTok, nil)
+		if !ok || gotUID != uid {
+			t.Errorf("token round-trip = (%d,%v); want (%d,true)", gotUID, ok, uid)
+		}
+	}
+}
+
+// TestAdminLabel checks the "who did it" name, including the fallback when an
+// admin has no username or first name.
+func TestAdminLabel(t *testing.T) {
+	if got := adminLabel(gotgbot.User{Id: 7, Username: "atur", FirstName: "Atur"}); got != "@atur" {
+		t.Errorf("adminLabel with username = %q; want @atur", got)
+	}
+	if got := adminLabel(gotgbot.User{Id: 7, FirstName: "Atur"}); got != "Atur" {
+		t.Errorf("adminLabel without username = %q; want Atur", got)
+	}
+	if got := adminLabel(gotgbot.User{Id: 7}); got != "7" {
+		t.Errorf("adminLabel with neither = %q; want the id", got)
+	}
+}

--- a/internal/bot/sendmsg.go
+++ b/internal/bot/sendmsg.go
@@ -234,8 +234,12 @@ func (b *Bot) sendMsgCore(ctx *ext.Context, userid string) (string, error) {
 		// note in sendMsgTemplate — the decorator's deletion is dead code.)
 	}
 
-	// trailing donation row
-	keyboard = append(keyboard, donationRow(b.Cfg.DonationLink))
+	// Trailing donation row — only when an admin has switched it on, since the
+	// button was removed by request. Both the flag and the link are runtime
+	// settings (see /admin_donate), so turning it back on needs no redeploy.
+	if b.Dyn.DonationEnabled() {
+		keyboard = append(keyboard, donationRow(b.Dyn.DonationLink()))
+	}
 	replyMarkup := gotgbot.InlineKeyboardMarkup{InlineKeyboard: keyboard}
 
 	// media groups: stash everything and wait for the rest of the group.

--- a/internal/bot/texts_inline.go
+++ b/internal/bot/texts_inline.go
@@ -60,8 +60,14 @@ const (
 	txtNotBlockedNow  = "همین الانش بلاک نیس"
 
 	// report callbacks
-	txtReportConfirm          = "آیا واقعا میخواهید این پیام را گزارش کنید؟"
-	txtReportCancelled        = "لغو شد"
+	txtReportConfirm   = "آیا واقعا میخواهید این پیام را گزارش کنید؟"
+	txtReportCancelled = "لغو شد"
+
+	// txtBannedNotice is sent to a user an admin bans from a report. Only the ban
+	// is announced: the user finds out anyway when the bot stops answering, so
+	// saying it plainly is clearer, while a merely-registered report stays silent.
+	txtBannedNotice = "🚫 دسترسی شما به این بات بسته شد.\n\n" +
+		"دلیلش گزارش‌های کاربران دیگه از پیام‌های شما بوده. اگر فکر می‌کنید اشتباهی پیش اومده، از طریق کانال با ما در تماس باشید."
 	txtReportedFromTargetChat = "این پیام از چت گیرنده کپی شد. ممکنه تهش تگ دلخواه داشته باشه"
 	btnReportYes              = "✅ آره ریپورتش کن"
 	btnReportNo               = "❌ نهههه"

--- a/internal/dynset/dynset.go
+++ b/internal/dynset/dynset.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"strconv"
 	"sync"
 )
 
@@ -14,21 +15,23 @@ import (
 // singleton. It is safe for concurrent use (the admin command writes while the
 // AI worker reads).
 type Settings struct {
-	path           string
-	defaultURL     string
-	defaultSession string
+	path            string
+	defaultURL      string
+	defaultSession  string
+	defaultDonation string
 
 	mu       sync.RWMutex
 	settings map[string]string
 }
 
 // New loads the settings file (if present) and records the config defaults.
-func New(path, defaultURL, defaultSession string) *Settings {
+func New(path, defaultURL, defaultSession, defaultDonation string) *Settings {
 	s := &Settings{
-		path:           path,
-		defaultURL:     defaultURL,
-		defaultSession: defaultSession,
-		settings:       map[string]string{},
+		path:            path,
+		defaultURL:      defaultURL,
+		defaultSession:  defaultSession,
+		defaultDonation: defaultDonation,
+		settings:        map[string]string{},
 	}
 	s.load()
 	return s
@@ -109,3 +112,25 @@ func (s *Settings) SetAISessionID(id string) { s.set("ai_session_id", id) }
 
 // ResetAISessionID clears the AI session id override.
 func (s *Settings) ResetAISessionID() { s.reset("ai_session_id") }
+
+// DonationEnabled reports whether the donation button should be shown under
+// delivered messages. It defaults to FALSE: the button was removed by request,
+// and an admin turns it back on with /admin_donate active. Living here rather
+// than in the env config is deliberate — toggling it is a runtime decision that
+// must not need a redeploy.
+func (s *Settings) DonationEnabled() bool { return s.get("donation_enabled", "false") == "true" }
+
+// SetDonationEnabled turns the donation button on or off and persists the choice.
+func (s *Settings) SetDonationEnabled(on bool) {
+	s.set("donation_enabled", strconv.FormatBool(on))
+}
+
+// DonationLink returns the donation URL, falling back to the config default
+// (DONATION_LINK) when an admin has not overridden it.
+func (s *Settings) DonationLink() string { return s.get("donation_link", s.defaultDonation) }
+
+// SetDonationLink overrides the donation URL.
+func (s *Settings) SetDonationLink(url string) { s.set("donation_link", url) }
+
+// ResetDonationLink drops the override, restoring the configured DONATION_LINK.
+func (s *Settings) ResetDonationLink() { s.reset("donation_link") }

--- a/internal/dynset/dynset_test.go
+++ b/internal/dynset/dynset_test.go
@@ -11,7 +11,7 @@ func TestDynsetPersistResetAndDefaults(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "dynamic_settings.json")
 
 	// no file yet -> config defaults.
-	s := New(path, "http://default-url", "default-session")
+	s := New(path, "http://default-url", "default-session", "https://donate.example")
 	if got := s.AIURL(); got != "http://default-url" {
 		t.Errorf("AIURL default = %q; want http://default-url", got)
 	}
@@ -27,7 +27,7 @@ func TestDynsetPersistResetAndDefaults(t *testing.T) {
 	}
 
 	// a fresh loader on the same path reads back the persisted overrides.
-	s2 := New(path, "http://default-url", "default-session")
+	s2 := New(path, "http://default-url", "default-session", "https://donate.example")
 	if got := s2.AIURL(); got != "http://override" {
 		t.Errorf("AIURL after reload = %q; want http://override (persisted)", got)
 	}
@@ -40,7 +40,7 @@ func TestDynsetPersistResetAndDefaults(t *testing.T) {
 	if got := s2.AIURL(); got != "http://default-url" {
 		t.Errorf("AIURL after reset = %q; want the default", got)
 	}
-	s3 := New(path, "http://default-url", "default-session")
+	s3 := New(path, "http://default-url", "default-session", "https://donate.example")
 	if got := s3.AIURL(); got != "http://default-url" {
 		t.Errorf("AIURL after reset+reload = %q; want the default", got)
 	}
@@ -67,8 +67,56 @@ func TestDynsetMalformedFileFallsBackToDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	// a malformed file must not crash New; it falls back to the config defaults.
-	s := New(path, "http://default-url", "default-session")
+	s := New(path, "http://default-url", "default-session", "https://donate.example")
 	if got := s.AIURL(); got != "http://default-url" {
 		t.Errorf("AIURL with malformed file = %q; want the default", got)
+	}
+}
+
+// TestDonationSettings covers the /admin_donate state: the button is OFF unless
+// an admin turned it on, the link falls back to the configured default, and both
+// survive a reload (the point of storing them here rather than in the env).
+func TestDonationSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dynamic_settings.json")
+	s := New(path, "u", "sess", "https://configured.example")
+
+	// Default OFF: the button was removed by request, so an untouched deployment
+	// must not show it.
+	if s.DonationEnabled() {
+		t.Error("DonationEnabled default = true; want false (button removed by default)")
+	}
+	if got := s.DonationLink(); got != "https://configured.example" {
+		t.Errorf("DonationLink default = %q; want the configured DONATION_LINK", got)
+	}
+
+	s.SetDonationEnabled(true)
+	s.SetDonationLink("https://new-donate.example")
+	if !s.DonationEnabled() {
+		t.Error("DonationEnabled after enabling = false")
+	}
+
+	// Reload: both settings persist, so a restart keeps what the admin set.
+	s2 := New(path, "u", "sess", "https://configured.example")
+	if !s2.DonationEnabled() {
+		t.Error("DonationEnabled did not persist across reload")
+	}
+	if got := s2.DonationLink(); got != "https://new-donate.example" {
+		t.Errorf("DonationLink after reload = %q; want the override", got)
+	}
+
+	// Turning it off persists too, and must not wipe the link.
+	s2.SetDonationEnabled(false)
+	s3 := New(path, "u", "sess", "https://configured.example")
+	if s3.DonationEnabled() {
+		t.Error("DonationEnabled=false did not persist")
+	}
+	if got := s3.DonationLink(); got != "https://new-donate.example" {
+		t.Errorf("disabling the button must not clear the link; got %q", got)
+	}
+
+	// Reset restores the configured default without touching the flag.
+	s3.ResetDonationLink()
+	if got := s3.DonationLink(); got != "https://configured.example" {
+		t.Errorf("DonationLink after reset = %q; want the configured default", got)
 	}
 }


### PR DESCRIPTION
Four separate commits, one per requested change, so each can be read (or reverted) on its own.

---

### 1. Contact links — `30fffae`

News channel → `t.me/chevalet_studio`. Support → `t.me/chevalet_studio?direct`. The separate programmer link is gone; the channel's direct chat serves both, so the two entries are merged.

Written as full `https://` URLs because the support entry carries a query string (`?direct`), which doesn't reliably auto-link in the bare `t.me/…` form. Nothing in the code referenced the old links (they were plain text, not `/start` deep-link handlers), so this is text-only.

### 2. Donation + spacer buttons — `456affa`

Both buttons removed from under delivered messages: the donation URL button, and the blank `" "` button the Python original used as a spacer between report and block (it did nothing — Telegram spreads two buttons across the row without it).

Donation isn't deleted, just off, and `/admin_donate` brings it back:

```
/admin_donate                -> show state
/admin_donate active         -> show the button
/admin_donate deactive       -> hide it (default)
/admin_donate link <url>     -> set the URL
/admin_donate link reset     -> back to the configured DONATION_LINK
```

Both the flag and the URL live in `dynamic_settings.json`, not the env, so toggling needs **no redeploy** and survives a restart. Also reachable as `/admin donate …` to match every other admin sub-command.

Two decisions worth flagging:
- **`/help` and `/donate` now read the same dynamic link.** Otherwise an admin who changed the link would have the texts and the button pointing at two different places.
- **A non-http(s) link is refused, not stored.** Telegram rejects an invalid URL button, which would make *every delivered message* fail to send — so this is a send-path guard, not cosmetic validation.

### 3. Report-channel action buttons — `865c4fd`

```
[ ✅ register report ] [ 🚫 ban ]
[ ✉️ message reporter ] [ ✉️ message reported ]
```

Three constraints shaped this:

**`REPORT_CHAT_ID` is a channel** (verified against the live chat: `type=channel`), and `prep` deliberately drops channel updates. So the callback handler is registered **outside prep** — the same exception `errMore` already makes for the error chat. Authority is `ADMINS`, checked server-side: being able to see the channel is not permission to ban.

**Composing can't happen in the channel** — the draft would be visible to everyone there. The bot asks in the admin's own private chat with a `ForceReply` prompt carrying the sealed target uid, and the reply is matched against the message it replies *to*. Nothing is held in memory, so a restart mid-compose is harmless. That reply handler sits ahead of the conversations with a filter narrow enough that only a reply to the bot's own prompt matches — otherwise the catch-all would deliver the admin's text as an anonymous message.

**`callback_data` carries sealed tokens, not raw uids.** The header already prints the reported uid for copy/paste, so this hides nothing from admins — it preserves the invariant that no real Telegram id ever goes in `callback_data`. A token is 31 chars, so `rpt|md|` + token is 38 of the 64 available; a test locks that, because exceeding it would make Telegram silently reject the whole keyboard and the report would post with no buttons.

After accept or ban, that row becomes a dead button naming the action and the admin, so two admins can't double-ban or double-count, and the channel keeps a record of who handled it. The message buttons stay usable.

Only a **ban** notifies the user, per your choice — they find out anyway when the bot stops answering, so saying it plainly is clearer, while warning someone about a merely-registered report mostly invites a fresh account. Notification is best effort: a user who blocked the bot must not fail a ban that's already committed.

### 4. Status-button fix — `a60ab23`

Caught while reviewing my own work: the spent status button used the generic `no-callback` data, whose handler runs *under prep* — the very thing these buttons avoid. A tap in the channel would never have been answered, leaving the client spinning. It now routes to the un-prepped handler.

---

## Verification

Full gate green: `go build`, `go vet`, `gofmt`, `go test -race -count=1 ./...` (7 packages).

New tests: the `/admin_donate` grammar (accepted spellings, and rejection of non-http links and injection-ish input), donation settings persistence across reload, the report keyboard's shape and 64-byte budget, that accept/ban target the *reported* user and never the reporter, that the done-swap kills only the action row, and that the bot's own compose prompt parses back to the right uid.

**One test caught a real bug:** `parseComposeRef` didn't strip a trailing `</code>`. Telegram strips HTML from `Message.Text` so it would probably have worked in production — but if that assumption ever broke, the whole compose flow would have failed *silently*. It now cuts the token on the base64url charset, so it no longer depends on that assumption.

Not yet verified live: report buttons need a real report to appear in the channel. I'll confirm after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)