### PR TITLE
fix(config): keep runtime settings across redeploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,4 +65,13 @@ BACKUP_CHAT_ID=
 BACKUP_TIME=02:17
 
 # --- Misc ---
+# Default donation URL. An admin can override it at runtime with
+# /admin_donate link <url>, and the donation button itself is off until
+# /admin_donate active.
 DONATION_LINK="https://daramet.com/Chevalet"
+
+# Where runtime-tunable settings (donation button, AI url/session) are persisted.
+# Optional; defaults to ./dynamic_settings.json. In Docker this MUST point at a
+# mounted path, otherwise every redeploy recreates the container and resets
+# whatever an admin configured (see deploy/go/docker-compose.cutover.yml).
+# DYNSET_PATH=/app/state/dynamic_settings.json

--- a/deploy/go/docker-compose.cutover.yml
+++ b/deploy/go/docker-compose.cutover.yml
@@ -26,10 +26,18 @@ services:
     init: true
     env_file:
       - .env.prod
+    environment:
+      # Keep runtime-tunable settings (the donation button, AI url/session) on the
+      # mounted state dir below. The default is the working directory, which lives
+      # in the container's throwaway layer — every redeploy recreates the container
+      # and would silently reset whatever an admin had configured.
+      DYNSET_PATH: /app/state/dynamic_settings.json
     volumes:
       # Host backups dir -> where `/admin backup` reads the newest dump. Filled
       # hourly by deploy/go/backup.sh (cron). Absolute path = this server's deploy.
       - /opt/chevalet-go-staging/backups:/app/backups
+      # Survives redeploys — see DYNSET_PATH above.
+      - /opt/chevalet-go-staging/state:/app/state
     networks:
       - prod
     healthcheck:

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -135,7 +135,7 @@ func New(cfg *config.Config, database *db.DB, txt *texts.Loader) (*Bot, error) {
 		DB:         database,
 		Cfg:        cfg,
 		Texts:      txt,
-		Dyn:        dynset.New("dynamic_settings.json", cfg.AIURL, cfg.AISessionID, cfg.DonationLink),
+		Dyn:        dynset.New(cfg.DynsetPath, cfg.AIURL, cfg.AISessionID, cfg.DonationLink),
 		Tokens:     tokens,
 		users:      newUserStore(),
 		aiQueue:    newAIQueue(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	BotID    string // BOT_TOKEN before the first ':'
 	Proxy    string
 
+	DynsetPath   string // where dynamic_settings.json lives (must be on a mount)
 	ReportChatID string
 	ErrorChatID  string
 	Admins       []string
@@ -121,6 +122,19 @@ func Load() (*Config, error) {
 		c.BotID = strings.SplitN(c.BotToken, ":", 2)[0]
 	}
 	c.Proxy = opt("PROXY", "")
+
+	// Where runtime-tunable settings (the AI url/session, the donation button) are
+	// persisted. Overridable because in Docker the working directory lives in the
+	// container's throwaway layer: writing there means every redeploy silently
+	// resets whatever an admin configured. Deployments point this at a mounted
+	// path; the default keeps local runs and the staging stack unchanged.
+	// An EMPTY value falls back to the default rather than through: os.WriteFile("")
+	// just errors, so an empty DYNSET_PATH= line in a .env would mean every admin
+	// setting is silently dropped with nothing but a log line to show for it.
+	c.DynsetPath = opt("DYNSET_PATH", "dynamic_settings.json")
+	if strings.TrimSpace(c.DynsetPath) == "" {
+		c.DynsetPath = "dynamic_settings.json"
+	}
 
 	c.ReportChatID = opt("REPORT_CHAT_ID", "")
 	c.ErrorChatID = opt("ERROR_CHAT_ID", "")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -168,3 +168,29 @@ func TestConfigLoadErrors(t *testing.T) {
 		t.Fatalf("Load() with bad int = %v; want a 'must be an integer' error", err)
 	}
 }
+
+// TestDynsetPathDefaultAndOverride pins the persistence path down. It matters
+// more than a normal optional setting: if this silently falls back to the working
+// directory inside a container, every redeploy wipes whatever an admin set with
+// /admin_donate, and nothing looks broken while it happens.
+func TestDynsetPathDefaultAndOverride(t *testing.T) {
+	setRequiredEnv(t)
+
+	t.Setenv("DYNSET_PATH", "")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if c.DynsetPath != "dynamic_settings.json" {
+		t.Errorf("DynsetPath default = %q; want dynamic_settings.json", c.DynsetPath)
+	}
+
+	t.Setenv("DYNSET_PATH", "/app/state/dynamic_settings.json")
+	c, err = Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if c.DynsetPath != "/app/state/dynamic_settings.json" {
+		t.Errorf("DynsetPath = %q; want the mounted override", c.DynsetPath)
+	}
+}

--- a/internal/dynset/dynset.go
+++ b/internal/dynset/dynset.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 )
@@ -62,6 +63,14 @@ func (s *Settings) save() {
 	if err != nil {
 		slog.Error("dynset: failed to marshal", "err", err)
 		return
+	}
+	// The path can point into a mounted directory that exists only as a mount
+	// point, so create the parent rather than losing the setting to ENOENT.
+	if dir := filepath.Dir(s.path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			slog.Error("dynset: failed to create settings dir", "dir", dir, "err", err)
+			return
+		}
 	}
 	if err := os.WriteFile(s.path, b, 0o600); err != nil {
 		slog.Error("dynset: failed to save", "err", err)


### PR DESCRIPTION
## The bug

Found while verifying #14 in production, before it could bite.

`dynset` wrote `dynamic_settings.json` to the working directory — `/app` in the container. The only mount is `/app/backups`:

```
$ docker inspect --format '{{range .Mounts}}...' chevalet-go-bot-prod
/opt/chevalet-go-staging/backups -> /app/backups (bind)
```

So running `/admin_donate active` would have written into the container's throwaway layer, and **the next deploy would have wiped it** — the container is recreated on every release. Nothing would look broken; the donation button would just quietly go back to hidden, and the admin would assume they'd mis-typed something. The same already applied to the AI url/session overrides.

## The fix

The path is now `DYNSET_PATH`, and the production compose mounts `/opt/chevalet-go-staging/state:/app/state` and points it there. The default is unchanged, so local runs and the staging stack behave exactly as before.

Two details that turn silent failure into working behaviour:

- **An empty `DYNSET_PATH` falls back to the default.** Config's `opt()` returns `""` for a set-but-empty var, and `os.WriteFile("")` merely errors — so a bare `DYNSET_PATH=` line in a `.env` would have dropped every admin setting with nothing but a log line. My own test caught this: I asserted the default and got `""`.
- **`save()` creates the parent directory**, since the configured path can point into a directory that exists only as a mount point.

## Verification

Full gate green: build, vet, gofmt, `go test -race -count=1 ./...` (7 packages). New config test covers the default, the override, and the empty-value fallback.

After deploy I'll confirm the state dir is mounted and that a write survives a container restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)