### PR TITLE
fix(errors): open error detail via a deep link, not a channel button

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -268,8 +268,11 @@ func (b *Bot) reportIncident(tg *gotgbot.Bot, ctx *ext.Context, code, summary st
 		if chatID, perr := strconv.ParseInt(b.Cfg.ErrorChatID, 10, 64); perr == nil {
 			b.errReports.put(code, detailPages)
 			opts := &gotgbot.SendMessageOpts{ParseMode: "HTML"}
-			if len(detailPages) > 0 {
-				opts.ReplyMarkup = moreButton(code, 0, len(detailPages))
+			// A link button, not a callback one: ERROR_CHAT_ID is a channel and
+			// channel callback buttons never reach the bot, so the old "more" button
+			// did nothing. The link opens the detail in the admin's private chat.
+			if len(detailPages) > 0 && b.TG.User.Username != "" {
+				opts.ReplyMarkup = moreLinkButton(b.TG.User.Username, code, len(detailPages))
 			}
 			_, _ = tg.SendMessage(chatID, summary, opts)
 		}

--- a/internal/bot/errreport.go
+++ b/internal/bot/errreport.go
@@ -2,12 +2,14 @@ package bot
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
 )
 
 // errReportStore keeps recent error reports' detail pages in memory so the
@@ -50,7 +52,28 @@ func (s *errReportStore) get(code string) ([]string, bool) {
 	return p, ok
 }
 
-// moreButton builds the inline keyboard that reveals page idx of report code.
+// errDeepLinkPrefix marks a /start payload as "open this error report". The
+// tracking code is 8 alphanumeric chars (encoder.GenerateCID), so the payload is
+// deep-link safe and far inside Telegram's 64-character limit.
+const errDeepLinkPrefix = "ERR-"
+
+// moreLinkButton is the button that goes on the report in ERROR_CHAT_ID.
+//
+// It is a LINK, not a callback: ERROR_CHAT_ID is a channel, and a callback button
+// on a channel post never reaches the bot (see reportactions.go — the tap is not
+// even sent by the client). This button therefore opened nothing for as long as it
+// existed. The link opens the admin's private chat, where paging works.
+func moreLinkButton(botUsername, code string, total int) gotgbot.InlineKeyboardMarkup {
+	return gotgbot.InlineKeyboardMarkup{InlineKeyboard: [][]gotgbot.InlineKeyboardButton{{
+		{
+			Text: fmt.Sprintf("🔎 جزئیات بیشتر (%d صفحه)", total),
+			Url:  "https://t.me/" + botUsername + "?start=" + errDeepLinkPrefix + code,
+		},
+	}}}
+}
+
+// moreButton builds the inline keyboard that reveals page idx of report code. Used
+// for paging INSIDE the admin's private chat, where callbacks do work.
 func moreButton(code string, idx, total int) gotgbot.InlineKeyboardMarkup {
 	return gotgbot.InlineKeyboardMarkup{InlineKeyboard: [][]gotgbot.InlineKeyboardButton{{
 		{
@@ -58,6 +81,46 @@ func moreButton(code string, idx, total int) gotgbot.InlineKeyboardMarkup {
 			CallbackData: "errmore|" + code + "|" + strconv.Itoa(idx),
 		},
 	}}}
+}
+
+// handleErrReport serves /start ERR-<code>: it shows page 1 of an error report's
+// detail in the admin's private chat, with a button for the next page.
+func (b *Bot) handleErrReport(tg *gotgbot.Bot, ctx *ext.Context, userid, arg string) error {
+	code := strings.TrimPrefix(arg, errDeepLinkPrefix)
+
+	// The link sits in a channel, so treat it as public: a non-admin gets the
+	// ordinary "didn't understand" reply rather than any hint that it means
+	// something.
+	if !b.isAdmin(userid) {
+		slog.Warn("error-report link followed by a non-admin", "actor", userid)
+		if e := b.otherMessagesTemplate(ctx); e != nil {
+			return e
+		}
+		return handlers.EndConversation()
+	}
+
+	pages, ok := b.errReports.get(code)
+	if !ok || len(pages) == 0 {
+		// Expected after a restart or eviction: the store is in-memory by design and
+		// the full detail is in the server logs.
+		if e := b.replyText(ctx, "این گزارش دیگه در حافظه نیست (جزئیات کامل در لاگ‌های سرور هست)."); e != nil {
+			return e
+		}
+		return handlers.EndConversation()
+	}
+
+	// Pages are stored ALREADY html-escaped — see errMore for why re-escaping here
+	// would corrupt the output and can overflow Telegram's 4096-char limit.
+	text := fmt.Sprintf("<b>جزئیات خطا</b> <code>%s</code> — صفحه 1/%d\n<pre>%s</pre>",
+		code, len(pages), pages[0])
+	opts := &gotgbot.SendMessageOpts{ParseMode: "HTML"}
+	if len(pages) > 1 {
+		opts.ReplyMarkup = moreButton(code, 1, len(pages))
+	}
+	if _, err := ctx.EffectiveMessage.Reply(tg, text, opts); err != nil {
+		return err
+	}
+	return handlers.EndConversation()
 }
 
 // errMore handles the "more" button on an error report in ERROR_CHAT_ID. It is
@@ -73,10 +136,18 @@ func (b *Bot) errMore(tg *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	msg := ctx.EffectiveMessage
 
-	// Defence in depth: only act on the configured error chat.
-	if msg != nil && b.Cfg.ErrorChatID != "" && strconv.FormatInt(msg.Chat.Id, 10) != b.Cfg.ErrorChatID {
-		_, _ = clbk.Answer(tg, nil)
-		return nil
+	// Paging now happens in an admin's PRIVATE chat (the channel button became a
+	// deep link), so accept either the configured error chat or a private chat with
+	// an admin — and nothing else.
+	if msg != nil {
+		inErrChat := b.Cfg.ErrorChatID != "" && strconv.FormatInt(msg.Chat.Id, 10) == b.Cfg.ErrorChatID
+		privateAdmin := msg.Chat.Type == "private" && b.isAdmin(strconv.FormatInt(clbk.From.Id, 10))
+		if !inErrChat && !privateAdmin {
+			slog.Warn("errmore refused", "chat", msg.Chat.Id, "type", msg.Chat.Type,
+				"actor", clbk.From.Id)
+			_, _ = clbk.Answer(tg, nil)
+			return nil
+		}
 	}
 
 	fields := strings.Split(clbk.Data, "|")

--- a/internal/bot/errreport_test.go
+++ b/internal/bot/errreport_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aturzone/chevaletAnonBot/internal/config"
+	"github.com/aturzone/chevaletAnonBot/internal/encoder"
 )
 
 func TestErrReportStoreEviction(t *testing.T) {
@@ -98,5 +99,59 @@ func TestAllowDBErrReport(t *testing.T) {
 	b.lastDBErr = time.Now().Add(-31 * time.Second)
 	if !b.allowDBErrReport() {
 		t.Fatal("a report after the window should be allowed again")
+	}
+}
+
+// TestErrDeepLink locks the error-report deep link. It is now the ONLY way into
+// the detail pages, since the channel button cannot be a callback button.
+func TestErrDeepLink(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		code := encoder.GenerateCID(8)
+		payload := errDeepLinkPrefix + code
+		if len(payload) > 64 {
+			t.Fatalf("payload %q is %d chars (>64)", payload, len(payload))
+		}
+		for j := 0; j < len(payload); j++ {
+			c := payload[j]
+			ok := (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+				(c >= '0' && c <= '9') || c == '_' || c == '-'
+			if !ok {
+				t.Fatalf("payload %q has %q, which Telegram rejects in a /start payload", payload, c)
+			}
+		}
+		// startCmd routes on prefixes; these must stay mutually exclusive or an
+		// error link would be handled as a report link (or as someone's cid).
+		if strings.HasPrefix(payload, "UNBLOCK-") || strings.HasPrefix(payload, reportDeepLinkPrefix) {
+			t.Fatalf("payload %q collides with another deep-link prefix", payload)
+		}
+		if strings.TrimPrefix(payload, errDeepLinkPrefix) != code {
+			t.Fatalf("round-trip of %q lost the code", payload)
+		}
+	}
+}
+
+// TestMoreLinkButtonIsAUrl is the regression guard for the actual bug: the button
+// posted into the error CHANNEL must be a URL button. A callback button there is
+// silently dead — the tap never reaches the bot.
+func TestMoreLinkButtonIsAUrl(t *testing.T) {
+	kb := moreLinkButton("Chevalet_bot", "abc12345", 3)
+	if len(kb.InlineKeyboard) != 1 || len(kb.InlineKeyboard[0]) != 1 {
+		t.Fatalf("keyboard shape = %v; want a single button", kb.InlineKeyboard)
+	}
+	btn := kb.InlineKeyboard[0][0]
+	if btn.CallbackData != "" {
+		t.Errorf("channel button has callback_data %q; it must be a URL button only", btn.CallbackData)
+	}
+	want := "https://t.me/Chevalet_bot?start=" + errDeepLinkPrefix + "abc12345"
+	if btn.Url != want {
+		t.Errorf("url = %q; want %q", btn.Url, want)
+	}
+
+	// The in-private paging button, by contrast, MUST be a callback button.
+	pg := moreButton("abc12345", 1, 3)
+	pgBtn := pg.InlineKeyboard[0][0]
+	if pgBtn.Url != "" || pgBtn.CallbackData != "errmore|abc12345|1" {
+		t.Errorf("paging button = (url %q, data %q); want a callback with errmore|abc12345|1",
+			pgBtn.Url, pgBtn.CallbackData)
 	}
 }

--- a/internal/bot/start.go
+++ b/internal/bot/start.go
@@ -40,6 +40,10 @@ func startCmd(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error {
 	if strings.HasPrefix(arg, reportDeepLinkPrefix) {
 		return b.handleReportCase(tg, ctx, userid, arg)
 	}
+	// Likewise the error channel's "more detail" link.
+	if strings.HasPrefix(arg, errDeepLinkPrefix) {
+		return b.handleErrReport(tg, ctx, userid, arg)
+	}
 	return b.startConnect(tg, ctx, userid, arg)
 }
 


### PR DESCRIPTION
The last place still relying on a channel callback button.

## The problem

The "🔎 more" button on error reports in `ERROR_CHAT_ID` **has never worked.** That chat is a channel, and a callback button on a channel post never reaches this bot — the client does not even send the tap. This was established while fixing the report buttons (#17), and the same mechanism was used here.

So every incident since the feature landed has posted a summary with an inert button, leaving the detail reachable only from the server logs.

## The fix

Identical shape to #17:

- The channel gets a **link button**, which needs no callback, deep-linking to `/start ERR-<code>`.
- Page 1 of the detail opens in the admin's **private chat**.
- The existing `errmore|` paging buttons then work from there, because callbacks do work in private chats.

`errMore`'s chat guard now accepts the error chat **or** a private chat with an admin, instead of the error chat alone, and logs a refusal rather than returning silently.

## Tests

The regression guard is the one that matters: **the channel button must carry a `url` and no `callback_data`**, while the in-private paging button must carry a callback. That is exactly the mistake that made this dead, and it would now fail the build.

Also covered: the payload stays inside Telegram's 64 characters, uses only characters Telegram accepts in a `/start` payload, and the `ERR-` prefix cannot collide with `UNBLOCK-` or `RPT-` (a collision would route an error link to the wrong handler, or worse, treat it as someone's anonymous cid).

A non-admin following the link gets the ordinary "didn't understand" reply — the link sits in a channel, so it must not hint that a tracking code means anything.

## Verification

`go build`, `go vet`, `gofmt`, `go test -race -count=1 ./...` — green **with a real PostgreSQL attached**, so the DB layer ran rather than skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)