### PR TITLE
fix(report): keep the channel's stamped button a working link

### DIFF
--- a/internal/bot/reportactions.go
+++ b/internal/bot/reportactions.go
@@ -342,12 +342,15 @@ func (b *Bot) rptStamp(tg *gotgbot.Bot, ctx *ext.Context, reportID, label string
 	if err != nil || c.ChannelChatID == 0 || c.ChannelMsgID == 0 {
 		return
 	}
-	// Replace the channel's link button with the outcome. Editing (not deleting)
-	// keeps the report itself readable as a record.
+	// Relabel the channel's button with the outcome, keeping it a LINK: a callback
+	// button here would be inert (channel taps never arrive) yet still look
+	// tappable, and an admin may well want to reopen the case afterwards to message
+	// either party. So the label carries the status and the button still works.
 	if _, _, err := tg.EditMessageReplyMarkup(&gotgbot.EditMessageReplyMarkupOpts{
-		ChatId:      c.ChannelChatID,
-		MessageId:   c.ChannelMsgID,
-		ReplyMarkup: ikb(row(cb(label, "rpt|done|-"))),
+		ChatId:    c.ChannelChatID,
+		MessageId: c.ChannelMsgID,
+		ReplyMarkup: ikb(row(urlBtn(label,
+			"https://t.me/"+b.TG.User.Username+"?start="+reportDeepLinkPrefix+c.ReportID))),
 	}); err != nil {
 		slog.Warn("could not stamp the report channel message",
 			"chat", c.ChannelChatID, "msg", c.ChannelMsgID, "err", err)


### PR DESCRIPTION
Found while auditing for anything still relying on a channel callback button, in preparation for a stable release.

The "handled by" stamp replaced the channel's link button with a **callback** button. It was meant to be inert — and it was, but for the wrong reason: a tap on a channel callback button never reaches the bot, so it looked tappable and silently did nothing. That is exactly the failure this whole change set exists to remove.

The stamp now relabels the button while keeping it a **link** back to the case. The outcome is visible, and an admin can still reopen it afterwards to message either party.

## Audit result

Every send to the two channel chats is now accounted for:

| Location | Sends to | Button |
|---|---|---|
| `bot.go` (incident report) | ERROR channel | link → `/start ERR-<code>` |
| `bot.go`, `background.go` (diagnostics) | ERROR channel | none |
| `callbacks.go` (new report) | REPORT channel | link → `/start RPT-<id>` |
| `reportactions.go` (stamp) | REPORT channel | link (this PR) |

Everything else with callback buttons goes to a private chat or the GM supergroup, where callbacks work.

## Verification

`go build`, `go vet`, `gofmt`, `go test -race -count=1 ./...` — green with a real PostgreSQL attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)