### PR TITLE
feat(admin): moderation panel and daily stats

### DIFF
--- a/Texts/admin.txt
+++ b/Texts/admin.txt
@@ -27,6 +27,9 @@
 <code>/admin ai-session set SESSION_ID</code>: set new AI session ID
 <code>/admin ai-session reset</code>: reset AI session ID to config default
 🔸---------------
+<code>/admin_reports</code>: reported users as buttons — open one to unban / ban / clear its reports / message it
+<code>/admin_stats</code>: daily active users, new users, messages + a 7-day trend
+🔸---------------
 <code>/admin_donate</code>: show the donation button state and link
 <code>/admin_donate active</code>: show the donation button under messages
 <code>/admin_donate deactive</code>: hide it (default)

--- a/internal/bot/adminmod.go
+++ b/internal/bot/adminmod.go
@@ -1,0 +1,292 @@
+package bot
+
+import (
+	"fmt"
+	"html"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+
+	"github.com/aturzone/chevaletAnonBot/internal/db"
+)
+
+// /admin_reports — the moderation panel, in the admin's private chat.
+//
+// Before this, reviewing reports meant `/admin report get all` (a wall of uids)
+// followed by hand-typed `/admin ban` and `/admin unban`, with the uid copied
+// between them. This lists reported users with their names, report counts and ban
+// state as buttons, and each user's panel unbans in one tap.
+//
+// Private chat only, on purpose: these are callback buttons, and callback buttons
+// on a channel post never reach the bot (see reportactions.go).
+const (
+	modPageSize = 8 // users per page; keeps the keyboard tappable on a phone
+
+	// Callback verbs. "am" = admin moderation.
+	modVerbPageReported = "pr" // list reported, page N
+	modVerbPageBanned   = "pb" // list banned, page N
+	modVerbView         = "v"  // open one user's panel
+	modVerbUnban        = "u"
+	modVerbBan          = "b"
+	modVerbClear        = "c" // clear that user's reports
+)
+
+// adminReportsCmd opens the panel.
+func adminReportsCmd(b *Bot, tg *gotgbot.Bot, ctx *ext.Context, userid string) error {
+	if !b.isAdmin(userid) {
+		return b.otherMessagesTemplate(ctx)
+	}
+	text, kb, err := b.modList(false, 0)
+	if err != nil {
+		return err
+	}
+	_, err = ctx.EffectiveMessage.Reply(tg, text, &gotgbot.SendMessageOpts{
+		ParseMode:   "HTML",
+		ReplyMarkup: kb,
+	})
+	return err
+}
+
+// modList renders one page of either the reported or the banned list.
+func (b *Bot) modList(banned bool, page int) (string, gotgbot.InlineKeyboardMarkup, error) {
+	dbctx, cancel := b.bg()
+	defer cancel()
+
+	var (
+		users []db.ModUser
+		err   error
+		title string
+		verb  string
+	)
+	if banned {
+		users, err = b.DB.GetBannedUsers(dbctx)
+		title, verb = "🚫 <b>کاربران بن شده</b>", modVerbPageBanned
+	} else {
+		users, err = b.DB.GetReportedUsers(dbctx)
+		title, verb = "⚠️ <b>کاربران ریپورت شده</b>", modVerbPageReported
+	}
+	if err != nil {
+		return "", gotgbot.InlineKeyboardMarkup{}, err
+	}
+
+	if len(users) == 0 {
+		empty := "هیچ کاربر ریپورت شده‌ای نیست 👌"
+		if banned {
+			empty = "هیچ کاربر بن شده‌ای نیست 👌"
+		}
+		return title + "\n\n" + empty, ikb(row(b.modSwitchButton(banned))), nil
+	}
+
+	// Clamp rather than error: a page can go stale when another admin acts.
+	pages := (len(users) + modPageSize - 1) / modPageSize
+	if page >= pages {
+		page = pages - 1
+	}
+	if page < 0 {
+		page = 0
+	}
+	start := page * modPageSize
+	end := min(start+modPageSize, len(users))
+
+	var sb strings.Builder
+	sb.WriteString(title)
+	sb.WriteString(fmt.Sprintf("\nصفحه %d از %d — مجموع %d کاربر\n", page+1, pages, len(users)))
+	sb.WriteString("\nروی هر کاربر بزن تا گزینه‌هاش باز شه.")
+
+	var rows [][]gotgbot.InlineKeyboardButton
+	for _, u := range users[start:end] {
+		tok, err := b.Tokens.Seal(mustInt64(u.UID), nil)
+		if err != nil {
+			return "", gotgbot.InlineKeyboardMarkup{}, err
+		}
+		rows = append(rows, row(cb(modUserLabel(u), "am|"+modVerbView+"|"+tok)))
+	}
+
+	// Paging row, only when there is more than one page.
+	if pages > 1 {
+		var nav []gotgbot.InlineKeyboardButton
+		if page > 0 {
+			nav = append(nav, cb("◀️ قبلی", "am|"+verb+"|"+strconv.Itoa(page-1)))
+		}
+		if page+1 < pages {
+			nav = append(nav, cb("بعدی ▶️", "am|"+verb+"|"+strconv.Itoa(page+1)))
+		}
+		if len(nav) > 0 {
+			rows = append(rows, nav)
+		}
+	}
+	rows = append(rows, row(b.modSwitchButton(banned)))
+
+	return sb.String(), gotgbot.InlineKeyboardMarkup{InlineKeyboard: rows}, nil
+}
+
+// modSwitchButton toggles between the reported and banned lists.
+func (b *Bot) modSwitchButton(showingBanned bool) gotgbot.InlineKeyboardButton {
+	if showingBanned {
+		return cb("⚠️ لیست ریپورت شده‌ها", "am|"+modVerbPageReported+"|0")
+	}
+	return cb("🚫 لیست بن شده‌ها", "am|"+modVerbPageBanned+"|0")
+}
+
+// modUserLabel is one button's caption: name, report count, and a ban marker.
+func modUserLabel(u db.ModUser) string {
+	name := strings.TrimSpace(u.Name)
+	if name == "" {
+		name = u.UID
+	}
+	// Telegram truncates long button captions, so cap the name and keep the
+	// counters — those are the part an admin is scanning for.
+	if len(name) > 24 {
+		name = name[:24] + "…"
+	}
+	label := fmt.Sprintf("%s — %d ریپورت", name, u.Reports)
+	if u.Banned {
+		label = "🚫 " + label
+	}
+	return label
+}
+
+// modUserPanel renders one user's actions.
+func (b *Bot) modUserPanel(uid, token string) (string, gotgbot.InlineKeyboardMarkup, error) {
+	dbctx, cancel := b.bg()
+	defer cancel()
+
+	u, err := b.DB.GetModUser(dbctx, uid)
+	if err != nil {
+		return "", gotgbot.InlineKeyboardMarkup{}, err
+	}
+
+	state := "✅ فعال"
+	if u.Banned {
+		state = "🚫 بن شده"
+	}
+	name := strings.TrimSpace(u.Name)
+	if name == "" {
+		name = "(بدون نام)"
+	}
+	text := "👤 <b>" + html.EscapeString(name) + "</b>\n" +
+		"آیدی: " + hrefUser(u.UID, "") + "\n" +
+		"وضعیت: " + state + "\n" +
+		"ریپورت‌ها: <b>" + strconv.Itoa(u.Reports) + "</b>"
+
+	var actions []gotgbot.InlineKeyboardButton
+	if u.Banned {
+		actions = append(actions, cb("🔓 آنبلاک (رفع بن)", "am|"+modVerbUnban+"|"+token))
+	} else {
+		actions = append(actions, cb("🚫 بن کردن", "am|"+modVerbBan+"|"+token))
+	}
+	rows := [][]gotgbot.InlineKeyboardButton{actions}
+	if u.Reports > 0 {
+		rows = append(rows, row(cb("🧹 پاک کردن ریپورت‌ها", "am|"+modVerbClear+"|"+token)))
+	}
+	rows = append(rows,
+		row(cb("✉️ پیام به این کاربر", "rpt|"+rptVerbMsgReported+"|"+token)),
+		row(cb("↩️ برگشت به لیست", "am|"+modVerbPageReported+"|0")),
+	)
+	return text, gotgbot.InlineKeyboardMarkup{InlineKeyboard: rows}, nil
+}
+
+// adminMod handles every "am|" button. Registered outside prep and admin-checked
+// here, matching the other admin callback paths.
+func (b *Bot) adminMod(tg *gotgbot.Bot, ctx *ext.Context) error {
+	clbk := ctx.CallbackQuery
+	if clbk == nil || clbk.Data == "" {
+		return nil
+	}
+	actor := strconv.FormatInt(clbk.From.Id, 10)
+	if !b.isAdmin(actor) {
+		slog.Warn("admin moderation button used by a non-admin", "actor", actor)
+		_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+			Text:      "فقط ادمین‌ها.",
+			ShowAlert: true,
+		})
+		return nil
+	}
+
+	fields := strings.SplitN(clbk.Data, "|", 3)
+	if len(fields) != 3 {
+		_, _ = clbk.Answer(tg, nil)
+		return nil
+	}
+	verb, arg := fields[1], fields[2]
+
+	switch verb {
+	case modVerbPageReported, modVerbPageBanned:
+		page, _ := strconv.Atoi(arg)
+		text, kb, err := b.modList(verb == modVerbPageBanned, page)
+		if err != nil {
+			return err
+		}
+		_, _ = clbk.Answer(tg, nil)
+		return b.modEdit(tg, ctx, text, kb)
+
+	case modVerbView, modVerbUnban, modVerbBan, modVerbClear:
+		uid, ok := b.Tokens.Open(arg, nil)
+		if !ok {
+			_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+				Text:      "این دکمه دیگه معتبر نیست.",
+				ShowAlert: true,
+			})
+			return nil
+		}
+		uidStr := strconv.FormatInt(uid, 10)
+
+		dbctx, cancel := b.bg()
+		defer cancel()
+		switch verb {
+		case modVerbUnban:
+			if err := b.DB.BanAction(dbctx, uidStr, false); err != nil {
+				return err
+			}
+			slog.Info("user unbanned by admin", "target", uidStr, "actor", actor)
+			_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{Text: "بن برداشته شد ✅", ShowAlert: true})
+		case modVerbBan:
+			if err := b.DB.BanAction(dbctx, uidStr, true); err != nil {
+				return err
+			}
+			slog.Info("user banned by admin", "target", uidStr, "actor", actor)
+			_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{Text: "کاربر بن شد 🚫", ShowAlert: true})
+		case modVerbClear:
+			n, err := b.DB.DelReportID(dbctx, uidStr)
+			if err != nil {
+				return err
+			}
+			slog.Info("reports cleared by admin", "target", uidStr, "count", n, "actor", actor)
+			_, _ = clbk.Answer(tg, &gotgbot.AnswerCallbackQueryOpts{
+				Text:      strconv.Itoa(n) + " ریپورت پاک شد 🧹",
+				ShowAlert: true,
+			})
+		default:
+			_, _ = clbk.Answer(tg, nil)
+		}
+
+		// Always re-render the panel afterwards, so the state an admin sees is the
+		// state in the database rather than what it was before their tap.
+		text, kb, err := b.modUserPanel(uidStr, arg)
+		if err != nil {
+			return err
+		}
+		return b.modEdit(tg, ctx, text, kb)
+
+	default:
+		_, _ = clbk.Answer(tg, nil)
+		return nil
+	}
+}
+
+// modEdit replaces the panel in place. "message is not modified" is expected when
+// a tap produces no visible change and is swallowed by tgerr's benign-error list.
+func (b *Bot) modEdit(tg *gotgbot.Bot, ctx *ext.Context, text string, kb gotgbot.InlineKeyboardMarkup) error {
+	msg := ctx.EffectiveMessage
+	if msg == nil {
+		return nil
+	}
+	_, _, err := msg.EditText(tg, text, &gotgbot.EditMessageTextOpts{
+		ParseMode:   "HTML",
+		ReplyMarkup: kb,
+	})
+	return err
+}

--- a/internal/bot/adminmod_test.go
+++ b/internal/bot/adminmod_test.go
@@ -1,0 +1,78 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aturzone/chevaletAnonBot/internal/db"
+)
+
+// TestModUserLabel covers the button caption an admin scans down the list.
+func TestModUserLabel(t *testing.T) {
+	if got := modUserLabel(db.ModUser{UID: "123", Name: "Atur", Reports: 3}); got != "Atur — 3 ریپورت" {
+		t.Errorf("label = %q; want the name and count", got)
+	}
+
+	// A banned user must be obvious at a glance without opening the panel.
+	got := modUserLabel(db.ModUser{UID: "123", Name: "Atur", Reports: 3, Banned: true})
+	if !strings.HasPrefix(got, "🚫 ") {
+		t.Errorf("banned label = %q; want a 🚫 marker", got)
+	}
+
+	// No name (a report against an account with no users row): fall back to the uid
+	// rather than rendering a blank, unidentifiable button.
+	if got := modUserLabel(db.ModUser{UID: "999", Reports: 1}); !strings.HasPrefix(got, "999") {
+		t.Errorf("label with no name = %q; want the uid as the fallback", got)
+	}
+
+	// A very long name must not push the counts out of the visible caption, which is
+	// the part being scanned.
+	long := strings.Repeat("ب", 200)
+	got = modUserLabel(db.ModUser{UID: "1", Name: long, Reports: 7})
+	if !strings.Contains(got, "7 ریپورت") {
+		t.Errorf("long-name label dropped the count: %q", got)
+	}
+	if len(got) > 80 {
+		t.Errorf("label is %d bytes; too long for a button caption", len(got))
+	}
+}
+
+// TestFormatStats checks the dashboard states its own limits, so a number is never
+// read as more than it is.
+func TestFormatStats(t *testing.T) {
+	out := formatStats(db.Stats{
+		TotalUsers: 17250, TotalLinks: 17406, TotalReports: 15, TotalBanned: 2,
+		UsersWithoutJoinDate: 17170,
+		Today:                db.DayStat{NewUsers: 4, Active: 31, Messages: 128},
+	})
+
+	for _, want := range []string{"17250", "17406", "128", "31", "4"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stats output is missing %q", want)
+		}
+	}
+	// The caveats matter more than the figures: without them "4 new users" against
+	// 17k existing rows invites the wrong conclusion.
+	if !strings.Contains(out, "17170") {
+		t.Error("output does not disclose how many users predate join-date tracking")
+	}
+	if !strings.Contains(out, "دقیقه") {
+		t.Error("output does not explain that past-day 'active' differs from today's")
+	}
+}
+
+// TestFormatStatsEmpty guards the first-run case: a brand-new deployment with no
+// activity at all must still render, not divide by zero or hide sections oddly.
+func TestFormatStatsEmpty(t *testing.T) {
+	out := formatStats(db.Stats{})
+	if out == "" {
+		t.Fatal("empty stats produced no output")
+	}
+	if !strings.Contains(out, "امروز") {
+		t.Error("empty stats output lost the today section")
+	}
+	// With nothing to disclose, the join-date caveat must not appear at all.
+	if strings.Contains(out, "ثبت نشده") {
+		t.Error("the join-date caveat appeared even though no users lack a join date")
+	}
+}

--- a/internal/bot/adminstats.go
+++ b/internal/bot/adminstats.go
@@ -1,0 +1,82 @@
+package bot
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+
+	"github.com/aturzone/chevaletAnonBot/internal/db"
+)
+
+// /admin_stats — the daily admin dashboard.
+//
+// What it reports, and what it deliberately cannot:
+//
+//   - new users: users.created_at, which is NULL for everyone who joined before
+//     tracking started. Those are reported separately rather than folded in, so a
+//     daily figure is never confused with the whole user base.
+//   - active users: users.last_active_at, written at most once per user per day.
+//   - messages: a per-day counter, incremented on delivery.
+//
+// Nothing here records who messaged whom — the counter has no sender, recipient or
+// content, and last_active_at says only THAT someone used the bot. That is the
+// anonymity contract, and stats are not worth weakening it.
+//
+// One honest limitation: last_active_at holds only the LATEST day a user was seen,
+// so a past day's "active" means "users whose last activity was that day". Today's
+// figure is exact. The reply says so rather than quietly implying otherwise.
+func adminStatsCmd(b *Bot, _ *gotgbot.Bot, ctx *ext.Context, userid string) error {
+	if !b.isAdmin(userid) {
+		return b.otherMessagesTemplate(ctx)
+	}
+
+	dbctx, cancel := b.bg()
+	defer cancel()
+
+	s, err := b.DB.GetStats(dbctx, 7)
+	if err != nil {
+		return err
+	}
+	return b.replyHTML(ctx, formatStats(s), true)
+}
+
+// formatStats renders the dashboard. Kept separate from the command so the layout
+// is testable without a database or Telegram.
+func formatStats(s db.Stats) string {
+	var sb strings.Builder
+
+	sb.WriteString("📊 <b>آمار روزانه</b>\n\n")
+
+	sb.WriteString("<b>امروز</b>\n")
+	sb.WriteString(fmt.Sprintf("• کاربر جدید: <b>%d</b>\n", s.Today.NewUsers))
+	sb.WriteString(fmt.Sprintf("• کاربر فعال: <b>%d</b>\n", s.Today.Active))
+	sb.WriteString(fmt.Sprintf("• پیام ارسال شده: <b>%d</b>\n\n", s.Today.Messages))
+
+	sb.WriteString("<b>کل</b>\n")
+	sb.WriteString(fmt.Sprintf("• کاربران: <b>%d</b>\n", s.TotalUsers))
+	sb.WriteString(fmt.Sprintf("• لینک‌ها: <b>%d</b>\n", s.TotalLinks))
+	sb.WriteString(fmt.Sprintf("• ریپورت‌ها: <b>%d</b>\n", s.TotalReports))
+	sb.WriteString(fmt.Sprintf("• بن شده: <b>%d</b>\n", s.TotalBanned))
+
+	if len(s.Days) > 0 {
+		sb.WriteString("\n<b>۷ روز گذشته</b>\n<pre>")
+		sb.WriteString("روز          جدید  فعال   پیام\n")
+		for _, d := range s.Days {
+			sb.WriteString(fmt.Sprintf("%-12s %5d %5d %6d\n",
+				d.Day.Format("2006-01-02"), d.NewUsers, d.Active, d.Messages))
+		}
+		sb.WriteString("</pre>")
+	}
+
+	// State the caveats instead of letting a number be read as more than it is.
+	sb.WriteString("\n<blockquote>«فعال» برای روزهای گذشته یعنی کاربرانی که آخرین فعالیتشون اون روز بوده؛ عدد امروز دقیقه.")
+	if s.UsersWithoutJoinDate > 0 {
+		sb.WriteString(fmt.Sprintf("\nتاریخ عضویت %d کاربر ثبت نشده (قبل از فعال شدن آمار عضو شدن)، پس توی «کاربر جدید» شمرده نمیشن.",
+			s.UsersWithoutJoinDate))
+	}
+	sb.WriteString("</blockquote>")
+
+	return sb.String()
+}

--- a/internal/bot/handlers.go
+++ b/internal/bot/handlers.go
@@ -64,6 +64,12 @@ func (b *Bot) registerHandlers() {
 	b.command("donate", cmdDonate)
 	b.command("admin", adminCmd)
 	b.command("admin_donate", adminDonateCmd)
+	b.command("admin_reports", adminReportsCmd)
+	b.command("admin_stats", adminStatsCmd)
+
+	// The moderation panel's buttons. Outside prep like the other admin callback
+	// paths, and admin-checked inside the handler.
+	d.AddHandler(handlers.NewCallback(cqfilters.Prefix("am|"), b.adminMod))
 	b.command("myuid", cmdMyUID)
 	b.command("bug", cmdBug)
 

--- a/internal/bot/prep.go
+++ b/internal/bot/prep.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strconv"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
@@ -81,6 +82,13 @@ func (b *Bot) prep(fn Handler) handlers.Response {
 		}
 		if banned {
 			return nil // banned users are silently ignored, as in the original
+		}
+
+		// Record activity for the daily stats. Best effort on purpose: this is a
+		// reporting nicety, and a hiccup here must never stop a user's message from
+		// being handled. It writes at most once per user per day (see TouchUser).
+		if terr := b.DB.TouchUser(dbctx, userid); terr != nil {
+			slog.Warn("could not record user activity", "err", terr)
 		}
 
 		return b.handleErr(tg, ctx, fn(b, tg, ctx, userid))

--- a/internal/bot/sendmsg.go
+++ b/internal/bot/sendmsg.go
@@ -430,6 +430,13 @@ func (b *Bot) warningHandle(ctx *ext.Context, wasChannelReply bool, targetUID, u
 		sentText = txtSentToThem
 	}
 
+	// Count the delivery for the daily stats. Reached only once the message is
+	// actually through, so the figure means "delivered", not "attempted". Best
+	// effort: a counter must never fail a send that already succeeded.
+	if cerr := b.DB.CountMessage(dbctx); cerr != nil {
+		slog.Warn("could not count a delivered message", "err", cerr)
+	}
+
 	showWarning := wasChannelReply
 	if !showWarning {
 		w, err := b.DB.GetWarning(dbctx, userid)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -156,6 +156,31 @@ func (db *DB) MakeTables(ctx context.Context) error {
 		`ALTER TABLE users ADD COLUMN IF NOT EXISTS anon_name VARCHAR(255)`,
 		`ALTER TABLE users ADD COLUMN IF NOT EXISTS anon_emoji VARCHAR(255)`,
 		`ALTER TABLE users ADD COLUMN IF NOT EXISTS anon_enabled BOOLEAN NOT NULL DEFAULT FALSE`,
+
+		// Columns backing the daily admin stats (/admin_stats).
+		//
+		// NOTE THE MISSING DEFAULT on created_at, and that it is added in two steps.
+		// Adding it WITH `DEFAULT now()` would stamp every one of the ~17k existing
+		// rows with the migration time, and the first stats report would claim they
+		// all joined today. Added bare, existing rows get NULL — honestly "joined
+		// before tracking started" — and the default is then set so only NEW users
+		// are stamped.
+		`ALTER TABLE users ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ`,
+		`ALTER TABLE users ALTER COLUMN created_at SET DEFAULT now()`,
+
+		// last_active_at powers "active users today". It records only THAT a user
+		// used the bot, never who they talked to — the anonymity model forbids
+		// storing the pairing, and nothing here does.
+		`ALTER TABLE users ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMPTZ`,
+		`CREATE INDEX IF NOT EXISTS users_last_active_at_idx ON users (last_active_at)`,
+		`CREATE INDEX IF NOT EXISTS users_created_at_idx ON users (created_at)`,
+
+		// daily_metrics is a pure per-day COUNTER. Deliberately not a message log:
+		// counting deliveries needs no sender, no recipient and no content, so the
+		// bot can report volume without recording who messaged whom.
+		`CREATE TABLE IF NOT EXISTS daily_metrics (
+			day DATE PRIMARY KEY,
+			messages BIGINT NOT NULL DEFAULT 0)`,
 	}
 	for _, s := range stmts {
 		if _, err := db.pool.Exec(ctx, s); err != nil {

--- a/internal/db/moderation.go
+++ b/internal/db/moderation.go
@@ -1,0 +1,81 @@
+package db
+
+import "context"
+
+// ModUser is one row of the admin moderation list.
+type ModUser struct {
+	UID     string
+	Name    string
+	Reports int
+	Banned  bool
+}
+
+// GetReportedUsers lists everyone with at least one report, worst first.
+//
+// One query with a join rather than GetAllReports plus a GetName per uid: the list
+// is rendered as a keyboard, so N round trips would be N per page for no reason.
+func (db *DB) GetReportedUsers(ctx context.Context) ([]ModUser, error) {
+	rows, err := db.pool.Query(ctx,
+		`SELECT r.reported_id,
+		        COALESCE(u.name, ''),
+		        count(*) AS c,
+		        COALESCE(u.is_banned, FALSE)
+		   FROM reports r
+		   LEFT JOIN users u ON u.uid = r.reported_id
+		  GROUP BY r.reported_id, u.name, u.is_banned
+		  ORDER BY c DESC, r.reported_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanModUsers(rows)
+}
+
+// GetBannedUsers lists every banned user, with how many reports they carry (which
+// may be zero — an admin can ban directly).
+func (db *DB) GetBannedUsers(ctx context.Context) ([]ModUser, error) {
+	rows, err := db.pool.Query(ctx,
+		`SELECT u.uid,
+		        COALESCE(u.name, ''),
+		        (SELECT count(*) FROM reports r WHERE r.reported_id = u.uid),
+		        TRUE
+		   FROM users u
+		  WHERE u.is_banned
+		  ORDER BY u.uid`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanModUsers(rows)
+}
+
+// GetModUser loads one user for the per-user action panel. A uid with reports but
+// no users row still returns a usable entry, so a report can be cleared even when
+// the account is gone.
+func (db *DB) GetModUser(ctx context.Context, uid string) (ModUser, error) {
+	m := ModUser{UID: uid}
+	err := db.pool.QueryRow(ctx,
+		`SELECT COALESCE((SELECT name FROM users WHERE uid=$1), ''),
+		        (SELECT count(*) FROM reports WHERE reported_id=$1),
+		        COALESCE((SELECT is_banned FROM users WHERE uid=$1), FALSE)`, uid).
+		Scan(&m.Name, &m.Reports, &m.Banned)
+	return m, err
+}
+
+type rowScanner interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+}
+
+func scanModUsers(rows rowScanner) ([]ModUser, error) {
+	var out []ModUser
+	for rows.Next() {
+		var m ModUser
+		if err := rows.Scan(&m.UID, &m.Name, &m.Reports, &m.Banned); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"context"
+	"time"
+)
+
+// DayStat is one day's activity.
+type DayStat struct {
+	Day      time.Time
+	NewUsers int
+	Active   int
+	Messages int64
+}
+
+// Stats is the /admin_stats payload.
+type Stats struct {
+	TotalUsers   int
+	TotalLinks   int
+	TotalReports int
+	TotalBanned  int
+	// UsersWithoutJoinDate are rows that predate created_at tracking. Surfaced so
+	// a "new users" figure can never be mistaken for the whole user base.
+	UsersWithoutJoinDate int
+	Today                DayStat
+	Days                 []DayStat // most recent first, excluding today
+}
+
+// TouchUser records that a user was active, at most one write per user per day.
+//
+// The WHERE clause is the point: it matches only when the stored value is from
+// before today, so the common case is an UPDATE that touches no row rather than a
+// write on every single update the bot handles.
+func (db *DB) TouchUser(ctx context.Context, uid string) error {
+	_, err := db.pool.Exec(ctx,
+		`UPDATE users SET last_active_at = now()
+		  WHERE uid = $1
+		    AND (last_active_at IS NULL OR last_active_at < current_date)`, uid)
+	return err
+}
+
+// CountMessage adds one to today's delivered-message counter.
+//
+// A counter, not a log: no sender, no recipient, no content. Volume can be
+// reported without recording who messaged whom.
+func (db *DB) CountMessage(ctx context.Context) error {
+	_, err := db.pool.Exec(ctx,
+		`INSERT INTO daily_metrics (day, messages) VALUES (current_date, 1)
+		 ON CONFLICT (day) DO UPDATE SET messages = daily_metrics.messages + 1`)
+	return err
+}
+
+// GetStats gathers the totals, today, and the previous days days of history.
+func (db *DB) GetStats(ctx context.Context, days int) (Stats, error) {
+	var s Stats
+	if days < 1 {
+		days = 7
+	}
+
+	err := db.pool.QueryRow(ctx,
+		`SELECT (SELECT count(*) FROM users),
+		        (SELECT count(*) FROM cids),
+		        (SELECT count(*) FROM reports),
+		        (SELECT count(*) FROM users WHERE is_banned),
+		        (SELECT count(*) FROM users WHERE created_at IS NULL)`).
+		Scan(&s.TotalUsers, &s.TotalLinks, &s.TotalReports, &s.TotalBanned, &s.UsersWithoutJoinDate)
+	if err != nil {
+		return s, err
+	}
+
+	// COALESCE wraps the SUBQUERY, not the column: with no daily_metrics row yet
+	// (any day before the first delivered message) an inner COALESCE never runs and
+	// the subquery yields NULL, which would fail the scan and break /admin_stats
+	// outright.
+	err = db.pool.QueryRow(ctx,
+		`SELECT (SELECT count(*) FROM users WHERE created_at >= current_date),
+		        (SELECT count(*) FROM users WHERE last_active_at >= current_date),
+		        COALESCE((SELECT messages FROM daily_metrics WHERE day = current_date), 0)`).
+		Scan(&s.Today.NewUsers, &s.Today.Active, &s.Today.Messages)
+	if err != nil {
+		return s, err
+	}
+	s.Today.Day = time.Now()
+
+	// One row per past day. Active counts come from last_active_at, which only ever
+	// holds the LATEST day a user was seen — so a past day's "active" is the number
+	// of users whose last activity was that day, not everyone who used the bot then.
+	// Messages are exact; that distinction is spelled out in the reply.
+	rows, err := db.pool.Query(ctx,
+		`SELECT d::date,
+		        (SELECT count(*) FROM users WHERE created_at::date = d::date),
+		        (SELECT count(*) FROM users WHERE last_active_at::date = d::date),
+		        COALESCE((SELECT messages FROM daily_metrics WHERE day = d::date), 0)
+		   FROM generate_series(current_date - $1::int, current_date - 1, interval '1 day') AS d
+		  ORDER BY d DESC`, days)
+	if err != nil {
+		return s, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var ds DayStat
+		if err := rows.Scan(&ds.Day, &ds.NewUsers, &ds.Active, &ds.Messages); err != nil {
+			return s, err
+		}
+		s.Days = append(s.Days, ds)
+	}
+	return s, rows.Err()
+}

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -1,0 +1,186 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// TestStatsAndModeration runs the new admin queries against a real PostgreSQL.
+//
+// The migration behaviour is the important part: created_at is added WITHOUT a
+// default so pre-existing rows stay NULL. If it were added with `DEFAULT now()`,
+// every existing user would be stamped with the migration time and the first
+// stats report would claim ~17k people joined today.
+func TestStatsAndModeration(t *testing.T) {
+	ctx := context.Background()
+	d, err := Connect(ctx, testConfig(t))
+	noErr(t, err, "Connect")
+	defer d.Close()
+
+	// Simulate the real upgrade path against a REALISTIC schema: build the current
+	// one, then drop exactly the columns this change adds, so the second MakeTables
+	// exercises the same migration production ran.
+	_, err = d.pool.Exec(ctx, `DROP TABLE IF EXISTS users, cids, reports, blocks, report_cases, daily_metrics`)
+	noErr(t, err, "drop")
+	noErr(t, d.MakeTables(ctx), "MakeTables (baseline)")
+	_, err = d.pool.Exec(ctx, `ALTER TABLE users DROP COLUMN created_at, DROP COLUMN last_active_at`)
+	noErr(t, err, "strip the new columns")
+	_, err = d.pool.Exec(ctx, `DROP TABLE daily_metrics`)
+	noErr(t, err, "strip daily_metrics")
+
+	// Two users that exist BEFORE the columns are added.
+	_, err = d.pool.Exec(ctx, `INSERT INTO users (uid, name) VALUES ('old1','Old One'), ('old2','Old Two')`)
+	noErr(t, err, "insert legacy users")
+
+	noErr(t, d.MakeTables(ctx), "MakeTables (migration)")
+
+	// The whole point: existing users must NOT look like today's signups.
+	s, err := d.GetStats(ctx, 7)
+	noErr(t, err, "GetStats")
+	if s.Today.NewUsers != 0 {
+		t.Errorf("NewUsers today = %d after migrating 2 pre-existing users; want 0", s.Today.NewUsers)
+	}
+	if s.UsersWithoutJoinDate != 2 {
+		t.Errorf("UsersWithoutJoinDate = %d; want 2 (reported separately, not hidden)", s.UsersWithoutJoinDate)
+	}
+	if s.TotalUsers != 2 {
+		t.Errorf("TotalUsers = %d; want 2", s.TotalUsers)
+	}
+
+	// A user added after the migration IS counted as new today.
+	added, err := d.AddUser(ctx, "new1", "New One")
+	noErr(t, err, "AddUser")
+	if !added {
+		t.Fatal("AddUser reported the user already existed")
+	}
+	s, err = d.GetStats(ctx, 7)
+	noErr(t, err, "GetStats after AddUser")
+	if s.Today.NewUsers != 1 {
+		t.Errorf("NewUsers today = %d after one signup; want 1", s.Today.NewUsers)
+	}
+
+	// Activity: nobody is active until touched, then exactly the touched user is.
+	if s.Today.Active != 0 {
+		t.Errorf("Active today = %d before any touch; want 0", s.Today.Active)
+	}
+	noErr(t, d.TouchUser(ctx, "new1"), "TouchUser")
+	// Touching twice must not double-count — it writes at most once per day.
+	noErr(t, d.TouchUser(ctx, "new1"), "TouchUser (again)")
+	s, err = d.GetStats(ctx, 7)
+	noErr(t, err, "GetStats after touch")
+	if s.Today.Active != 1 {
+		t.Errorf("Active today = %d after touching one user twice; want 1", s.Today.Active)
+	}
+
+	// Message counter: starts at zero, accumulates, and stays one row per day.
+	for i := 0; i < 5; i++ {
+		noErr(t, d.CountMessage(ctx), "CountMessage")
+	}
+	s, err = d.GetStats(ctx, 7)
+	noErr(t, err, "GetStats after counting")
+	if s.Today.Messages != 5 {
+		t.Errorf("Messages today = %d; want 5", s.Today.Messages)
+	}
+	var dayRows int
+	noErr(t, d.pool.QueryRow(ctx, `SELECT count(*) FROM daily_metrics`).Scan(&dayRows), "count daily_metrics")
+	if dayRows != 1 {
+		t.Errorf("daily_metrics rows = %d after 5 messages in one day; want 1", dayRows)
+	}
+
+	// The history window returns exactly the requested number of past days.
+	if len(s.Days) != 7 {
+		t.Errorf("history days = %d; want 7", len(s.Days))
+	}
+
+	// ---- moderation lists ----
+	noErr(t, d.pool.QueryRow(ctx, `SELECT 1`).Scan(new(int)), "ping")
+	if _, err := d.AddReportID(ctx, "new1"); err != nil {
+		t.Fatalf("AddReportID: %v", err)
+	}
+	if _, err := d.AddReportID(ctx, "new1"); err != nil {
+		t.Fatalf("AddReportID: %v", err)
+	}
+	if _, err := d.AddReportID(ctx, "old1"); err != nil {
+		t.Fatalf("AddReportID: %v", err)
+	}
+
+	reported, err := d.GetReportedUsers(ctx)
+	noErr(t, err, "GetReportedUsers")
+	if len(reported) != 2 {
+		t.Fatalf("reported users = %d; want 2", len(reported))
+	}
+	// Worst offender first — that is the ordering an admin needs.
+	if reported[0].UID != "new1" || reported[0].Reports != 2 {
+		t.Errorf("first row = (%s,%d); want (new1,2) — highest count first",
+			reported[0].UID, reported[0].Reports)
+	}
+	if reported[0].Name != "New One" {
+		t.Errorf("name = %q; want New One (joined from users)", reported[0].Name)
+	}
+	if reported[0].Banned {
+		t.Error("user reported as banned before any ban")
+	}
+
+	// Banning shows up in both the flag and the banned list.
+	noErr(t, d.BanAction(ctx, "new1", true), "BanAction(ban)")
+	banned, err := d.GetBannedUsers(ctx)
+	noErr(t, err, "GetBannedUsers")
+	if len(banned) != 1 || banned[0].UID != "new1" {
+		t.Fatalf("banned users = %+v; want just new1", banned)
+	}
+	if banned[0].Reports != 2 {
+		t.Errorf("banned user's report count = %d; want 2", banned[0].Reports)
+	}
+
+	one, err := d.GetModUser(ctx, "new1")
+	noErr(t, err, "GetModUser")
+	if !one.Banned || one.Reports != 2 || one.Name != "New One" {
+		t.Errorf("GetModUser = %+v; want banned, 2 reports, New One", one)
+	}
+
+	// One-click unban is the headline feature: it must actually clear the flag and
+	// empty the banned list.
+	noErr(t, d.BanAction(ctx, "new1", false), "BanAction(unban)")
+	banned, err = d.GetBannedUsers(ctx)
+	noErr(t, err, "GetBannedUsers after unban")
+	if len(banned) != 0 {
+		t.Errorf("banned users after unban = %+v; want none", banned)
+	}
+
+	// Clearing reports removes them from the reported list entirely.
+	n, err := d.DelReportID(ctx, "new1")
+	noErr(t, err, "DelReportID")
+	if n != 2 {
+		t.Errorf("DelReportID returned %d; want 2", n)
+	}
+	reported, err = d.GetReportedUsers(ctx)
+	noErr(t, err, "GetReportedUsers after clear")
+	if len(reported) != 1 || reported[0].UID != "old1" {
+		t.Errorf("reported after clearing new1 = %+v; want only old1", reported)
+	}
+
+	// A report against a uid with no users row must still be listed and clearable,
+	// so a report can be handled after the account is gone.
+	if _, err := d.AddReportID(ctx, "ghost"); err != nil {
+		t.Fatalf("AddReportID(ghost): %v", err)
+	}
+	reported, err = d.GetReportedUsers(ctx)
+	noErr(t, err, "GetReportedUsers with a ghost")
+	found := false
+	for _, r := range reported {
+		if r.UID == "ghost" {
+			found = true
+			if r.Name != "" || r.Banned {
+				t.Errorf("ghost row = %+v; want empty name and not banned", r)
+			}
+		}
+	}
+	if !found {
+		t.Error("a report against an unknown uid vanished from the list")
+	}
+	ghost, err := d.GetModUser(ctx, "ghost")
+	noErr(t, err, "GetModUser(ghost)")
+	if ghost.Reports != 1 {
+		t.Errorf("ghost reports = %d; want 1", ghost.Reports)
+	}
+}


### PR DESCRIPTION
## `/admin_reports` — reported users as buttons

Name, report count and a 🚫 marker, 8 per page, with a toggle to a banned-only list. Opening a user gives **unban** (or ban), **clear reports**, and **message**.

Before this, reviewing a report meant `/admin report get all` — a wall of uids — then hand-typing `/admin ban` / `/admin unban` with the uid copied between them.

A report against a uid with no `users` row still lists and clears, so a report can be handled after the account is gone.

## `/admin_stats` — daily dashboard

New users, active users and delivered messages for today; running totals; a 7-day trend.

### Three things worth stating plainly

**Nothing records who messaged whom.** The message figure is a per-day counter with no sender, recipient or content, and `last_active_at` says only *that* a user used the bot. Volume reporting isn't worth weakening the anonymity model for.

**`created_at` is added without a default, then the default is set** — two statements, deliberately. Adding it as `DEFAULT now()` would stamp all ~17k existing rows with the migration time, and the first report would claim they all joined today. Pre-existing rows keep `NULL` — honestly "joined before tracking" — and are reported *separately* so a daily figure can't be mistaken for the user base.

**For past days, "active" means users whose *latest* activity was that day**, because `last_active_at` holds one timestamp per user, not a history. Today's figure is exact. The reply says so rather than implying otherwise.

Both trackers are best effort — a reporting nicety must never fail a user's message. `TouchUser`'s `WHERE` matches nothing after the first call each day, so this is not a write per update.

## A bug the database test caught

`COALESCE` sat **inside** the message subquery, so on any day with no `daily_metrics` row the subquery returned `NULL`, the scan failed, and **`/admin_stats` would have errored outright** — including the very first time you ran it. It now wraps the subquery.

The test also drives the real upgrade path (build the schema → drop the new columns → migrate) and asserts the 17k-existing-users case directly, rather than trusting my reasoning about it.

## Also answered: the seen-button question

Not a bug. `sendmsg.go:196` reads the **sender's** `seen_option`, so the recipient is offered a seen button only when the sender wants a read receipt. Verified in production: your account has it on, and 17,170 of 17,253 users have it off (the default). No change made.

## Verification

`go build`, `go vet`, `gofmt`, `go test -race -count=1 ./...` — green **with a real PostgreSQL attached**.

New tests cover the migration path, the counter's one-row-per-day behaviour, double-touch not double-counting, worst-offender ordering, one-click unban clearing the list, ghost uids, long/blank button captions, and that the dashboard discloses its own caveats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)