### PR TITLE
feat: pace every outbound Telegram call to stay under the rate limits

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -50,11 +50,9 @@ type Bot struct {
 	admins     map[string]bool
 	errReports *errReportStore
 
-	// floodUntil is a Telegram-imposed send pause (a 429 retry_after); see
-	// noteFloodWait. Guarded by floodMu together with the report throttle.
-	floodMu         sync.Mutex
-	floodUntil      time.Time
-	lastFloodReport time.Time
+	// limiter paces every outbound Telegram call and owns the flood pause. See
+	// ratelimit.go for why this lives at the BotClient layer.
+	limiter *sendLimiter
 
 	// convStores holds the three ConversationHandlers' state storages so a stale
 	// flow can be dropped when the user starts a different one. Without this, a
@@ -113,6 +111,8 @@ func (b *Bot) allowDBErrReport() bool {
 
 // New builds the Telegram bot, dispatcher and updater, and registers handlers.
 func New(cfg *config.Config, database *db.DB, txt *texts.Loader) (*Bot, error) {
+	limiter := newSendLimiter()
+
 	botOpts := &gotgbot.BotOpts{
 		RequestOpts: &gotgbot.RequestOpts{Timeout: 10 * time.Second},
 	}
@@ -128,6 +128,14 @@ func New(cfg *config.Config, database *db.DB, txt *texts.Loader) (*Bot, error) {
 			DefaultRequestOpts: &gotgbot.RequestOpts{Timeout: 30 * time.Second},
 		}
 	}
+
+	// Every API call goes through the limiter — including the ones a future change
+	// adds, which is the point of doing it here rather than per call site.
+	base := botOpts.BotClient
+	if base == nil {
+		base = &gotgbot.BaseBotClient{DefaultRequestOpts: botOpts.RequestOpts}
+	}
+	botOpts.BotClient = &limitedClient{inner: base, limiter: limiter}
 
 	tg, err := gotgbot.NewBot(cfg.BotToken, botOpts)
 	if err != nil {
@@ -154,6 +162,7 @@ func New(cfg *config.Config, database *db.DB, txt *texts.Loader) (*Bot, error) {
 		aiQueue:    newAIQueue(),
 		admins:     make(map[string]bool, len(cfg.Admins)),
 		errReports: newErrReportStore(50),
+		limiter:    limiter,
 	}
 	for _, a := range cfg.Admins {
 		b.admins[a] = true
@@ -319,38 +328,9 @@ func (b *Bot) reportToErrorChat(tg *gotgbot.Bot, text string) {
 // is recorded once and every outbound path checks it first. That is the difference
 // between a 90-second pause and the 607-second ban that was observed.
 
-// noteFloodWait records a Telegram-imposed wait, keeping the furthest deadline.
-func (b *Bot) noteFloodWait(seconds int64) {
-	if seconds <= 0 {
-		seconds = 5 // Telegram sometimes omits the value; back off a little anyway.
-	}
-	b.floodMu.Lock()
-	defer b.floodMu.Unlock()
-	until := time.Now().Add(time.Duration(seconds) * time.Second)
-	if until.After(b.floodUntil) {
-		b.floodUntil = until
-	}
-}
-
-// floodWaitRemaining reports how long Telegram still wants us to wait, 0 if clear.
-func (b *Bot) floodWaitRemaining() time.Duration {
-	b.floodMu.Lock()
-	defer b.floodMu.Unlock()
-	if d := time.Until(b.floodUntil); d > 0 {
-		return d
-	}
-	return 0
-}
+// noteFloodWait records a Telegram-imposed wait so every outbound call backs off.
+func (b *Bot) noteFloodWait(seconds int64) { b.limiter.noteFloodWait(seconds) }
 
 // allowFloodReport throttles the admin notice to one per two minutes, so a flood
 // does not produce a flood of reports about the flood.
-func (b *Bot) allowFloodReport() bool {
-	b.floodMu.Lock()
-	defer b.floodMu.Unlock()
-	now := time.Now()
-	if !b.lastFloodReport.IsZero() && now.Sub(b.lastFloodReport) < 2*time.Minute {
-		return false
-	}
-	b.lastFloodReport = now
-	return true
-}
+func (b *Bot) allowFloodReport() bool { return b.limiter.allowReport() }

--- a/internal/bot/ratelimit.go
+++ b/internal/bot/ratelimit.go
@@ -1,0 +1,329 @@
+package bot
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+)
+
+// Outbound rate limiting for EVERY Telegram API call.
+//
+// WHY HERE: gotgbot funnels every method through BotClient.RequestWithContext, so
+// wrapping that covers copyMessage, sendMessage, editMessageText, sendMediaGroup
+// and everything else at once. Handling it per call site would mean finding all of
+// them and getting each one right forever.
+//
+// WHAT IT FIXES: the bot was exceeding Telegram's limits and being told to back off
+// for up to 607 seconds. 321 such errors were logged in nine hours. Telegram's
+// documented ceilings are roughly 30 messages/second overall, about one per second
+// to a single user, and ~20 per minute to a group or channel. Nothing paced sends
+// against them, so bursts went straight into a flood wait.
+//
+// THE CONSTRAINT THAT SHAPES THE DESIGN: the dispatcher runs with MaxRoutines=1
+// (deliberately — the conversation and media-group state machines depend on strict
+// ordering), so a blocking send stalls ALL update processing. Waiting a full second
+// on a per-chat limit would throttle the whole bot to one update per second.
+//
+// So waits are bounded: a call waits at most maxInlineWait, which smooths bursts —
+// the common case — without ever parking the pipeline. Past that the call fails
+// fast, handleErr tells that one user to retry, and everyone else keeps moving.
+// Slowing one sender beats stalling the bot.
+const (
+	// Global ceiling, kept under Telegram's ~30/s with room for the API calls that
+	// are not sends (answerCallbackQuery, edits).
+	globalRatePerSec = 22
+	globalBurst      = 22
+
+	// A single private chat: Telegram tolerates about 1/s, with short bursts.
+	privateRatePerSec = 1.0
+	privateBurst      = 3
+
+	// A group or channel: ~20/minute. This is what the report and error channels
+	// live under, and what a flood there costs.
+	groupRatePerMin = 20.0
+	groupBurst      = 4
+
+	// The longest a single call will wait for a token. Bounded because of
+	// MaxRoutines=1 above.
+	maxInlineWait = 3 * time.Second
+
+	// A 429 shorter than this is slept through and retried once, since a two-second
+	// pause is cheaper than failing the user's message. Longer waits are reported
+	// upward instead of holding the pipeline.
+	maxInlineRetry = 2 * time.Second
+
+	// Per-chat buckets are pruned past this many entries, so 17k users cannot grow
+	// the map without bound.
+	maxTrackedChats = 4000
+	chatBucketIdle  = 10 * time.Minute
+)
+
+// tokenBucket is a leaky bucket that permits debt: a caller that cannot be served
+// now still takes its turn, and the wait it is told about accounts for everyone
+// already queued. That makes the queue fair instead of letting a burst starve
+// whoever arrived first.
+type tokenBucket struct {
+	capacity     float64
+	refillPerSec float64
+	tokens       float64
+	last         time.Time
+}
+
+func newTokenBucket(capacity, refillPerSec float64) *tokenBucket {
+	return &tokenBucket{capacity: capacity, refillPerSec: refillPerSec, tokens: capacity}
+}
+
+// reserve consumes one token and returns how long the caller must wait before it is
+// actually available. Zero means "go now".
+func (tb *tokenBucket) reserve(now time.Time) time.Duration {
+	if tb.last.IsZero() {
+		tb.last = now
+	}
+	if elapsed := now.Sub(tb.last).Seconds(); elapsed > 0 {
+		tb.tokens = math.Min(tb.capacity, tb.tokens+elapsed*tb.refillPerSec)
+		tb.last = now
+	}
+
+	tb.tokens--
+	if tb.tokens >= 0 {
+		return 0
+	}
+	// Debt is capped so a pathological burst cannot promise a wait of minutes.
+	if tb.tokens < -tb.capacity {
+		tb.tokens = -tb.capacity
+	}
+	return time.Duration((-tb.tokens / tb.refillPerSec) * float64(time.Second))
+}
+
+// chatBucket pairs a bucket with when it was last used, for pruning.
+type chatBucket struct {
+	bucket *tokenBucket
+	seen   time.Time
+}
+
+// sendLimiter paces outbound calls and owns the Telegram-imposed flood pause.
+type sendLimiter struct {
+	mu         sync.Mutex
+	global     *tokenBucket
+	perChat    map[int64]*chatBucket
+	floodUntil time.Time
+	lastReport time.Time
+
+	// Injectable for tests: real time makes rate-limit tests slow and flaky.
+	now   func() time.Time
+	sleep func(ctx context.Context, d time.Duration) error
+}
+
+func newSendLimiter() *sendLimiter {
+	return &sendLimiter{
+		global:  newTokenBucket(globalBurst, globalRatePerSec),
+		perChat: make(map[int64]*chatBucket),
+		now:     time.Now,
+		sleep:   sleepCtx,
+	}
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// noteFloodWait records a Telegram-imposed pause, keeping the furthest deadline.
+func (l *sendLimiter) noteFloodWait(seconds int64) {
+	if seconds <= 0 {
+		seconds = 5
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if until := l.now().Add(time.Duration(seconds) * time.Second); until.After(l.floodUntil) {
+		l.floodUntil = until
+	}
+}
+
+// floodWaitRemaining reports how long Telegram still wants us to wait.
+func (l *sendLimiter) floodWaitRemaining() time.Duration {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if d := l.floodUntil.Sub(l.now()); d > 0 {
+		return d
+	}
+	return 0
+}
+
+// allowReport throttles the admin notice to one per two minutes, so a flood does
+// not produce a flood of reports about the flood.
+func (l *sendLimiter) allowReport() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	if !l.lastReport.IsZero() && now.Sub(l.lastReport) < 2*time.Minute {
+		return false
+	}
+	l.lastReport = now
+	return true
+}
+
+// reserve returns the wait this call must observe: the larger of the global and
+// per-chat reservations, plus any outstanding flood pause.
+func (l *sendLimiter) reserve(chatID int64) time.Duration {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+
+	wait := l.global.reserve(now)
+
+	if chatID != 0 {
+		cb, ok := l.perChat[chatID]
+		if !ok {
+			cb = &chatBucket{bucket: newChatBucket(chatID)}
+			l.perChat[chatID] = cb
+			l.pruneLocked(now)
+		}
+		cb.seen = now
+		if w := cb.bucket.reserve(now); w > wait {
+			wait = w
+		}
+	}
+
+	if fw := l.floodUntil.Sub(now); fw > wait {
+		wait = fw
+	}
+	return wait
+}
+
+// newChatBucket picks the limit by chat kind. Telegram ids are negative for
+// groups, supergroups and channels and positive for users, which is the only
+// signal available at this layer — and it is a stable one.
+func newChatBucket(chatID int64) *tokenBucket {
+	if chatID < 0 {
+		return newTokenBucket(groupBurst, groupRatePerMin/60.0)
+	}
+	return newTokenBucket(privateBurst, privateRatePerSec)
+}
+
+// pruneLocked drops idle per-chat buckets. Caller holds the lock.
+func (l *sendLimiter) pruneLocked(now time.Time) {
+	if len(l.perChat) <= maxTrackedChats {
+		return
+	}
+	for id, cb := range l.perChat {
+		if now.Sub(cb.seen) > chatBucketIdle {
+			delete(l.perChat, id)
+		}
+	}
+}
+
+// unlimitedMethods are calls that must not be delayed.
+//
+// getUpdates is the polling loop — throttling it would stall the bot rather than
+// protect it. answerCallbackQuery has a few seconds before Telegram calls the query
+// too old, and it produces no message, so delaying it only makes buttons feel
+// broken. The rest are metadata reads.
+var unlimitedMethods = map[string]bool{
+	"getUpdates":          true,
+	"getMe":               true,
+	"getFile":             true,
+	"answerCallbackQuery": true,
+	"getChat":             true,
+	"getChatMember":       true,
+	"setMyCommands":       true,
+	"getMyCommands":       true,
+	"logOut":              true,
+	"close":               true,
+}
+
+// limitedClient wraps a gotgbot BotClient with the limiter.
+type limitedClient struct {
+	inner   gotgbot.BotClient
+	limiter *sendLimiter
+	// onFlood is called when Telegram returns a 429, so the bot can report it.
+	onFlood func(retryAfter int64)
+}
+
+var _ gotgbot.BotClient = (*limitedClient)(nil)
+
+func (c *limitedClient) GetAPIURL(opts *gotgbot.RequestOpts) string { return c.inner.GetAPIURL(opts) }
+
+func (c *limitedClient) FileURL(token, path string, opts *gotgbot.RequestOpts) string {
+	return c.inner.FileURL(token, path, opts)
+}
+
+func (c *limitedClient) RequestWithContext(
+	ctx context.Context, token, method string, params map[string]any, opts *gotgbot.RequestOpts,
+) (json.RawMessage, error) {
+	if unlimitedMethods[method] {
+		return c.inner.RequestWithContext(ctx, token, method, params, opts)
+	}
+
+	if wait := c.limiter.reserve(chatIDFromParams(params)); wait > 0 {
+		if wait > maxInlineWait {
+			// Fail fast rather than park the single dispatch goroutine. Presented to
+			// the user as "busy, try again" by handleErr.
+			return nil, &gotgbot.TelegramError{
+				Method:      method,
+				Code:        429,
+				Description: "Too Many Requests: retry after " + strconv.FormatInt(int64(wait.Seconds())+1, 10),
+			}
+		}
+		if err := c.limiter.sleep(ctx, wait); err != nil {
+			return nil, err
+		}
+	}
+
+	raw, err := c.inner.RequestWithContext(ctx, token, method, params, opts)
+	if err == nil {
+		return raw, nil
+	}
+
+	// Telegram still said no: record the pause so every other caller backs off too,
+	// which is what stops a short wait escalating into a long ban.
+	if secs, ok := errTooManyRequests(err); ok {
+		c.limiter.noteFloodWait(secs)
+		if c.onFlood != nil {
+			c.onFlood(secs)
+		}
+		// One inline retry for a short wait: cheaper than failing the message.
+		if d := time.Duration(secs) * time.Second; d > 0 && d <= maxInlineRetry {
+			if serr := c.limiter.sleep(ctx, d); serr == nil {
+				return c.inner.RequestWithContext(ctx, token, method, params, opts)
+			}
+		}
+	}
+	return raw, err
+}
+
+// chatIDFromParams pulls chat_id out of a request. gotgbot passes params as
+// strings, but the other numeric shapes are handled so a future change cannot
+// silently disable per-chat limiting.
+func chatIDFromParams(params map[string]any) int64 {
+	v, ok := params["chat_id"]
+	if !ok {
+		return 0
+	}
+	switch n := v.(type) {
+	case string:
+		id, _ := strconv.ParseInt(n, 10, 64)
+		return id
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case float64:
+		return int64(n)
+	}
+	return 0
+}

--- a/internal/bot/ratelimit_test.go
+++ b/internal/bot/ratelimit_test.go
@@ -1,0 +1,302 @@
+package bot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+)
+
+// fakeClock drives the limiter deterministically. Real time would make these tests
+// slow and flaky, and would not let us assert the pacing precisely.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newTestLimiter wires a limiter to a fake clock, recording what it was asked to
+// sleep for instead of actually sleeping.
+func newTestLimiter() (*sendLimiter, *fakeClock, *[]time.Duration) {
+	clk := &fakeClock{t: time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)}
+	var slept []time.Duration
+	l := newSendLimiter()
+	l.now = clk.now
+	l.sleep = func(_ context.Context, d time.Duration) error {
+		slept = append(slept, d)
+		clk.advance(d) // sleeping really does pass time
+		return nil
+	}
+	return l, clk, &slept
+}
+
+// TestGlobalRateIsPaced is the core guarantee: a burst past the global burst size is
+// told to wait, which is what stops the bot exceeding ~30/s and earning a flood wait
+// in the first place.
+func TestGlobalRateIsPaced(t *testing.T) {
+	l, clk, _ := newTestLimiter()
+
+	// The burst is free — a quiet bot must not be slowed down.
+	for i := 0; i < globalBurst; i++ {
+		if w := l.reserve(0); w != 0 {
+			t.Fatalf("call %d inside the burst waited %v; the burst must be free", i, w)
+		}
+	}
+	w := l.reserve(0)
+	if w <= 0 {
+		t.Fatal("the call after the burst was not paced; the bot would exceed the global limit")
+	}
+	if w > time.Second {
+		t.Errorf("wait one call past the burst = %v; suspiciously long", w)
+	}
+
+	// After enough idle time the budget comes back.
+	clk.advance(2 * time.Second)
+	if w := l.reserve(0); w != 0 {
+		t.Errorf("wait after 2s idle = %v; the bucket did not refill", w)
+	}
+}
+
+// TestPerChatLimitProtectsOneUser covers the limit that bites in practice: several
+// messages to the SAME chat in a moment.
+func TestPerChatLimitProtectsOneUser(t *testing.T) {
+	l, _, _ := newTestLimiter()
+	const victim = int64(1142340791) // positive == private chat
+
+	for i := 0; i < privateBurst; i++ {
+		if w := l.reserve(victim); w != 0 {
+			t.Fatalf("call %d to one chat waited %v; the burst must be free", i, w)
+		}
+	}
+	if w := l.reserve(victim); w <= 0 {
+		t.Error("a 4th rapid message to one user was not paced")
+	}
+
+	// A DIFFERENT chat must not be punished for it, or one busy conversation would
+	// throttle everybody.
+	if w := l.reserve(5118145008); w != 0 {
+		t.Errorf("an unrelated chat waited %v because another chat was busy", w)
+	}
+}
+
+// TestChannelLimitIsMuchTighter: the report and error chats are channels, where
+// Telegram allows ~20/minute rather than ~1/second.
+func TestChannelLimitIsMuchTighter(t *testing.T) {
+	l, _, _ := newTestLimiter()
+	const channel = int64(-1002157529004) // negative == channel
+
+	for i := 0; i < groupBurst; i++ {
+		if w := l.reserve(channel); w != 0 {
+			t.Fatalf("call %d to a channel waited %v inside the burst", i, w)
+		}
+	}
+	if w := l.reserve(channel); w < 2*time.Second {
+		t.Errorf("channel pacing after the burst = %v; want seconds, not milliseconds", w)
+	}
+}
+
+// TestFloodWaitPausesEverything: once Telegram says "retry after N", every caller
+// backs off. Ignoring that is what turned a 92-second wait into 607.
+func TestFloodWaitPausesEverything(t *testing.T) {
+	l, clk, _ := newTestLimiter()
+
+	l.noteFloodWait(120)
+	if got := l.floodWaitRemaining(); got < 119*time.Second {
+		t.Fatalf("floodWaitRemaining = %v; want ~120s", got)
+	}
+	// Even a chat that has sent nothing is held back.
+	if w := l.reserve(999); w < 119*time.Second {
+		t.Errorf("a fresh chat got wait %v during a flood pause; want ~120s", w)
+	}
+
+	// A LONGER wait extends it; a shorter one must not shorten it.
+	l.noteFloodWait(300)
+	if got := l.floodWaitRemaining(); got < 299*time.Second {
+		t.Errorf("a longer flood wait did not extend the pause: %v", got)
+	}
+	l.noteFloodWait(5)
+	if got := l.floodWaitRemaining(); got < 299*time.Second {
+		t.Errorf("a shorter flood wait shortened the pause to %v", got)
+	}
+
+	clk.advance(301 * time.Second)
+	if got := l.floodWaitRemaining(); got != 0 {
+		t.Errorf("the pause did not clear after expiry: %v", got)
+	}
+}
+
+// TestReportThrottle stops the bot reporting one flood 321 times.
+func TestReportThrottle(t *testing.T) {
+	l, clk, _ := newTestLimiter()
+	if !l.allowReport() {
+		t.Fatal("the first report was suppressed")
+	}
+	for i := 0; i < 50; i++ {
+		if l.allowReport() {
+			t.Fatal("a second report slipped through inside the throttle window")
+		}
+	}
+	clk.advance(3 * time.Minute)
+	if !l.allowReport() {
+		t.Error("reporting never recovered after the window")
+	}
+}
+
+// --- the client wrapper -----------------------------------------------------
+
+type fakeInner struct {
+	calls   []string
+	err     error
+	errOnce bool
+	served  int
+}
+
+func (f *fakeInner) RequestWithContext(_ context.Context, _, method string, _ map[string]any, _ *gotgbot.RequestOpts) (json.RawMessage, error) {
+	f.calls = append(f.calls, method)
+	f.served++
+	if f.err != nil && (!f.errOnce || f.served == 1) {
+		return nil, f.err
+	}
+	return json.RawMessage(`{"ok":true}`), nil
+}
+func (f *fakeInner) GetAPIURL(*gotgbot.RequestOpts) string               { return "" }
+func (f *fakeInner) FileURL(string, string, *gotgbot.RequestOpts) string { return "" }
+
+// TestPollingIsNeverThrottled: getUpdates is the polling loop. Delaying it stalls
+// the bot rather than protecting it.
+func TestPollingIsNeverThrottled(t *testing.T) {
+	l, _, slept := newTestLimiter()
+	c := &limitedClient{inner: &fakeInner{}, limiter: l}
+
+	for i := 0; i < 200; i++ { // far more than any burst allows
+		if _, err := c.RequestWithContext(context.Background(), "t", "getUpdates", nil, nil); err != nil {
+			t.Fatalf("getUpdates %d failed: %v", i, err)
+		}
+	}
+	if len(*slept) != 0 {
+		t.Errorf("polling was delayed %d times; it must never be throttled", len(*slept))
+	}
+}
+
+// TestSendsArePacedAtTheChannelRate: a serial caller is smoothed to roughly the
+// channel limit, and no single wait exceeds the cap that keeps the pipeline moving.
+func TestSendsArePacedAtTheChannelRate(t *testing.T) {
+	l, _, slept := newTestLimiter()
+	c := &limitedClient{inner: &fakeInner{}, limiter: l}
+	params := map[string]any{"chat_id": "-1002157529004"} // a channel: tight limit
+
+	for i := 0; i < 12; i++ {
+		if _, err := c.RequestWithContext(context.Background(), "t", "sendMessage", params, nil); err != nil {
+			t.Fatalf("serial send %d failed: %v", i, err)
+		}
+	}
+	if len(*slept) == 0 {
+		t.Fatal("no send was ever paced; the channel limit is not being applied")
+	}
+	for _, d := range *slept {
+		if d > maxInlineWait {
+			t.Errorf("a call slept %v, past the %v cap that keeps the pipeline moving", d, maxInlineWait)
+		}
+	}
+}
+
+// TestFailsFastWhenDebtStacks: with callers already queued — the real shape under
+// load, since background jobs send alongside the dispatcher — the wait grows past
+// the cap, and the call must fail fast rather than park the pipeline.
+func TestFailsFastWhenDebtStacks(t *testing.T) {
+	l, _, _ := newTestLimiter()
+	c := &limitedClient{inner: &fakeInner{}, limiter: l}
+	const channel = int64(-1002157529004)
+
+	// Stack debt without letting any time pass, as concurrent callers would.
+	for i := 0; i < 12; i++ {
+		l.reserve(channel)
+	}
+
+	_, err := c.RequestWithContext(context.Background(), "t", "sendMessage",
+		map[string]any{"chat_id": "-1002157529004"}, nil)
+	if err == nil {
+		t.Fatal("a deeply queued send was accepted; it would have parked the dispatcher")
+	}
+	var te *gotgbot.TelegramError
+	if !errors.As(err, &te) || te.Code != 429 {
+		t.Errorf("fail-fast error = %v; want a 429 so handleErr tells the user to retry", err)
+	}
+}
+
+// TestTelegram429IsRecordedAndRetried: a real 429 must pause everyone AND be retried
+// once when the wait is short, rather than losing the user's message.
+func TestTelegram429IsRecordedAndRetried(t *testing.T) {
+	l, _, _ := newTestLimiter()
+	inner := &fakeInner{
+		err:     &gotgbot.TelegramError{Code: 429, Description: "Too Many Requests: retry after 1"},
+		errOnce: true,
+	}
+	var reported int64
+	c := &limitedClient{inner: inner, limiter: l, onFlood: func(s int64) { reported = s }}
+
+	raw, err := c.RequestWithContext(context.Background(), "t", "copyMessage",
+		map[string]any{"chat_id": "12345"}, nil)
+	if err != nil {
+		t.Fatalf("a 1-second flood wait was not retried: %v", err)
+	}
+	if string(raw) != `{"ok":true}` {
+		t.Errorf("retry returned %s", raw)
+	}
+	if reported != 1 {
+		t.Errorf("the flood was reported as %d; want 1", reported)
+	}
+	if len(inner.calls) != 2 {
+		t.Errorf("inner was called %d times; want 2 (original + one retry)", len(inner.calls))
+	}
+	// The pause itself is asserted by TestFloodWaitPausesEverything. Not re-checked
+	// here: the retry slept through the whole 1s, so by now it has legitimately
+	// expired — which is the correct behaviour, not a missing pause.
+}
+
+// TestLongFloodIsNotRetriedInline: a 607-second wait must not be slept through, or
+// the bot freezes for ten minutes.
+func TestLongFloodIsNotRetriedInline(t *testing.T) {
+	l, _, slept := newTestLimiter()
+	inner := &fakeInner{err: &gotgbot.TelegramError{Code: 429, Description: "Too Many Requests: retry after 607"}}
+	c := &limitedClient{inner: inner, limiter: l}
+
+	if _, err := c.RequestWithContext(context.Background(), "t", "copyMessage",
+		map[string]any{"chat_id": "12345"}, nil); err == nil {
+		t.Fatal("a 607-second flood wait was swallowed instead of reported")
+	}
+	for _, d := range *slept {
+		if d > maxInlineRetry {
+			t.Errorf("slept %v inline on a long flood wait; the bot would freeze", d)
+		}
+	}
+	if l.floodWaitRemaining() < 600*time.Second {
+		t.Errorf("the long wait was not recorded: %v", l.floodWaitRemaining())
+	}
+}
+
+// TestChatIDParsing guards per-chat limiting against a params shape change silently
+// disabling it — every send would then share only the global bucket.
+func TestChatIDParsing(t *testing.T) {
+	for _, tc := range []struct {
+		val  any
+		want int64
+	}{
+		{"12345", 12345},
+		{"-1002157529004", -1002157529004},
+		{int64(7), 7},
+		{int(8), 8},
+		{float64(9), 9},
+		{"not-a-number", 0},
+		{nil, 0},
+	} {
+		if got := chatIDFromParams(map[string]any{"chat_id": tc.val}); got != tc.want {
+			t.Errorf("chatIDFromParams(%v) = %d; want %d", tc.val, got, tc.want)
+		}
+	}
+	if got := chatIDFromParams(map[string]any{}); got != 0 {
+		t.Errorf("missing chat_id gave %d; want 0", got)
+	}
+}


### PR DESCRIPTION
The 429s were never a *handling* problem — they were a throughput problem. Nothing paced sends against Telegram's ceilings, so bursts went straight into a flood wait: 321 in nine hours, escalating to `retry after 607`. v1.9.0 stopped the bot amplifying it; this stops it happening.

## Where it lives

`gotgbot.BotClient.RequestWithContext` — the single choke point every API method passes through. `copyMessage`, `sendMessage`, `editMessageText`, `sendMediaGroup` and anything added later are all covered at once, instead of needing every call site found and kept correct forever.

## The limits

| Scope | Rate | Burst |
|---|---|---|
| Global | 22/s | 22 |
| One private chat | 1/s | 3 |
| One group/channel | 20/min | 4 |

Under Telegram's documented ~30/s, with headroom for the calls that aren't sends. Chat kind comes from the sign of `chat_id` (negative = group/channel) — the only signal available at this layer, and a stable one.

## The constraint that shaped the design

**The dispatcher runs `MaxRoutines: 1` on purpose** — the conversation and media-group state machines depend on strict ordering. So a blocking send stalls *all* update processing. Naively waiting a full second on a per-chat limit would throttle the whole bot to one update per second.

So waits are **capped**. Bursts get smoothed — the common case, invisible to users. A call that would wait longer **fails fast** with a 429, so `handleErr` tells that one user to retry while everyone else keeps moving. Slowing one sender beats stalling the bot.

## Flood waits

A real 429 is still recorded as a pause every caller observes, so a short wait cannot escalate the way it did. Short waits are slept through and retried once — cheaper than failing someone's message. A 607-second wait is reported upward instead of freezing the bot for ten minutes.

## Deliberately never throttled

- **`getUpdates`** — the polling loop. Delaying it stalls the bot rather than protecting it.
- **`answerCallbackQuery`** — sends no message, and Telegram expires the query in seconds, so delaying it only makes buttons feel broken.

Plus per-chat buckets are pruned past 4000 entries, so 17k users can't grow the map without bound.

## Tests

Driven by an **injected clock**, not sleeps — deterministic and instant:

- the burst is free (a quiet bot isn't slowed)
- pacing kicks in past it, and the bucket refills
- one busy chat does **not** punish another
- the channel rate is seconds, not milliseconds
- a flood pause holds *every* caller, only ever extends, never shortens, and clears on expiry
- the report throttle stops 321 reports about one flood
- polling is never delayed, across 200 calls
- fail-fast once debt stacks
- a 1s 429 is retried; a 607s one is **not** slept through
- `chat_id` parsing across every shape it can arrive in — a params change would otherwise silently disable per-chat limiting

Two of these caught my own wrong assumptions while writing them, which is why the fail-fast test now models concurrent callers rather than a serial one.

## Verification

`go build`, `go vet`, `gofmt`, `go test -race -count=1 ./...` — green **with a real PostgreSQL attached**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)