### PR TITLE
fix(ratelimit): never mute the bot, never let one spammer stall it

### DIFF
--- a/internal/bot/prep.go
+++ b/internal/bot/prep.go
@@ -129,6 +129,15 @@ func (b *Bot) handleErr(tg *gotgbot.Bot, ctx *ext.Context, err error) error {
 		return nil
 	case errForbidden(err): // covers "bot was blocked by the user" / "not a member"
 		return nil
+	case errors.Is(err, errFloodPaused):
+		// OUR pause, honouring Telegram's. Must NOT call noteFloodWait: recording a
+		// pause because we are already paused is the loop that muted the bot.
+		slog.Warn("send skipped: honouring a Telegram flood wait")
+		if ctx.EffectiveMessage != nil {
+			_, _ = ctx.EffectiveMessage.Reply(tg, txtTooManyRequests, nil)
+		}
+		return nil
+
 	case floodSeconds(err) > 0 || isFloodErr(err):
 		// A Telegram 429 is load, not a bug. Filing it as an incident was actively
 		// harmful: each incident posts to ERROR_CHAT_ID and replies a tracking code,

--- a/internal/bot/ratelimit.go
+++ b/internal/bot/ratelimit.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"strconv"
 	"sync"
@@ -29,10 +30,15 @@ import (
 // ordering), so a blocking send stalls ALL update processing. Waiting a full second
 // on a per-chat limit would throttle the whole bot to one update per second.
 //
-// So waits are bounded: a call waits at most maxInlineWait, which smooths bursts —
-// the common case — without ever parking the pipeline. Past that the call fails
-// fast, handleErr tells that one user to retry, and everyone else keeps moving.
-// Slowing one sender beats stalling the bot.
+// So pacing is a bounded DELAY, never a rejection: a call waits at most
+// maxInlineWait — which smooths bursts, the common case — and then sends anyway.
+// Dropping somebody's message to protect a rate limit is worse than occasionally
+// taking a 429 that is already handled.
+//
+// The only outright refusal is while Telegram itself has us paused, since the call
+// would be rejected regardless. That is errFloodPaused, NOT a 429 — keep the two
+// distinct, or handleErr records a pause because we are already paused and the bot
+// mutes itself.
 const (
 	// Global ceiling, kept under Telegram's ~30/s with room for the API calls that
 	// are not sends (answerCallbackQuery, edits).
@@ -48,9 +54,20 @@ const (
 	groupRatePerMin = 20.0
 	groupBurst      = 4
 
-	// The longest a single call will wait for a token. Bounded because of
-	// MaxRoutines=1 above.
-	maxInlineWait = 3 * time.Second
+	// The longest a single call will wait for a token — deliberately SHORT.
+	//
+	// This is the number that decides whether one spammer can freeze the bot. The
+	// dispatcher is serial (MaxRoutines=1), so every millisecond spent waiting here
+	// is a millisecond nobody else's update is being processed. At 3s, a user
+	// pushing their 40-per-minute allowance could park the pipeline for a minute at
+	// a time and the bot looked dead to everyone else — which is exactly what was
+	// reported.
+	//
+	// 300ms still smooths the micro-bursts that cause most 429s (a handful of sends
+	// landing in the same instant) while keeping the worst case per update small
+	// enough that a flood cannot starve other users. Beyond it the call sends
+	// anyway and an occasional real 429 is handled, which is the better trade.
+	maxInlineWait = 300 * time.Millisecond
 
 	// A 429 shorter than this is slept through and retried once, since a two-second
 	// pause is cheaper than failing the user's message. Longer waits are reported
@@ -199,9 +216,9 @@ func (l *sendLimiter) reserve(chatID int64) time.Duration {
 		}
 	}
 
-	if fw := l.floodUntil.Sub(now); fw > wait {
-		wait = fw
-	}
+	// The flood pause is deliberately NOT folded in here; the client checks it
+	// separately. Mixing it into the pacing wait is what let one pause become a
+	// self-sustaining lockup.
 	return wait
 }
 
@@ -246,6 +263,12 @@ var unlimitedMethods = map[string]bool{
 	"close":               true,
 }
 
+// errFloodPaused means Telegram has told us to wait and we are honouring it. It is
+// deliberately NOT a TelegramError with code 429: handleErr must be able to tell our
+// own back-pressure apart from Telegram's, or recording a pause in response to our
+// own pause becomes a loop that mutes the bot.
+var errFloodPaused = errors.New("bot: sending paused by a Telegram flood wait")
+
 // limitedClient wraps a gotgbot BotClient with the limiter.
 type limitedClient struct {
 	inner   gotgbot.BotClient
@@ -269,15 +292,29 @@ func (c *limitedClient) RequestWithContext(
 		return c.inner.RequestWithContext(ctx, token, method, params, opts)
 	}
 
+	// A real, Telegram-imposed pause is the only reason to refuse outright: the call
+	// WILL be rejected, so sending is pointless. Reported as its own sentinel, never
+	// as a 429 — see errFloodPaused.
+	if fw := c.limiter.floodWaitRemaining(); fw > 0 {
+		if fw > maxInlineWait {
+			return nil, errFloodPaused
+		}
+		if err := c.limiter.sleep(ctx, fw); err != nil {
+			return nil, err
+		}
+	}
+
+	// Pacing is a bounded DELAY, never a rejection. Waiting the cap and then sending
+	// anyway is the important choice: dropping somebody's message to protect a rate
+	// limit is worse than occasionally taking a 429 that is already handled.
+	//
+	// An earlier version returned a synthetic 429 here instead. handleErr could not
+	// tell it from Telegram's own, so back-pressure recorded a flood pause, the pause
+	// pushed every later call past the cap, and each of those extended it again — a
+	// loop that silently muted the bot, answers included.
 	if wait := c.limiter.reserve(chatIDFromParams(params)); wait > 0 {
 		if wait > maxInlineWait {
-			// Fail fast rather than park the single dispatch goroutine. Presented to
-			// the user as "busy, try again" by handleErr.
-			return nil, &gotgbot.TelegramError{
-				Method:      method,
-				Code:        429,
-				Description: "Too Many Requests: retry after " + strconv.FormatInt(int64(wait.Seconds())+1, 10),
-			}
+			wait = maxInlineWait
 		}
 		if err := c.limiter.sleep(ctx, wait); err != nil {
 			return nil, err

--- a/internal/bot/ratelimit_spam_test.go
+++ b/internal/bot/ratelimit_spam_test.go
@@ -1,0 +1,88 @@
+package bot
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestOneSpammerCannotStallTheBot is the regression test for the freeze.
+//
+// The dispatcher is serial (MaxRoutines=1), so any wait inside a send is time no
+// other user's update is being processed. With a 3-second cap, one user pushing
+// their per-minute allowance parked the pipeline for tens of seconds and the bot
+// looked dead to everybody else.
+//
+// This asserts the budget directly: a realistic flood from ONE chat must not cost
+// more than a small, bounded amount of total dispatcher time.
+func TestOneSpammerCannotStallTheBot(t *testing.T) {
+	l, _, slept := newTestLimiter()
+	c := &limitedClient{inner: &fakeInner{}, limiter: l}
+
+	// 40 sends is the per-user allowance (sendRateMax) — the most one user can push
+	// through in a minute before allowSend starts refusing them.
+	const floodSize = 40
+	params := map[string]any{"chat_id": "1988454449"} // one private chat
+	for i := 0; i < floodSize; i++ {
+		if _, err := c.RequestWithContext(context.Background(), "t", "copyMessage", params, nil); err != nil {
+			t.Fatalf("send %d in a flood was refused (%v); pacing must never drop a message", i, err)
+		}
+	}
+
+	var total time.Duration
+	for _, d := range *slept {
+		if d > maxInlineWait {
+			t.Errorf("a single send slept %v, past the %v cap", d, maxInlineWait)
+		}
+		total += d
+	}
+
+	// The whole flood must not monopolise the dispatcher. 40 sends × 300ms is the
+	// hard ceiling; anything near the old 3s cap (which reached ~2 minutes) means a
+	// spammer can starve other users again.
+	if max := floodSize * maxInlineWait; total > max {
+		t.Errorf("a %d-message flood cost %v of dispatcher time; ceiling is %v", floodSize, total, max)
+	}
+	if total > 15*time.Second {
+		t.Errorf("a single user's flood blocked the pipeline for %v; other users would see a dead bot", total)
+	}
+}
+
+// TestFloodFromManyUsersStaysResponsive: the realistic shape is many different
+// chats at once, where the per-chat limits do not apply and only the global one
+// does. That path must stay cheap.
+func TestFloodFromManyUsersStaysResponsive(t *testing.T) {
+	l, _, slept := newTestLimiter()
+	c := &limitedClient{inner: &fakeInner{}, limiter: l}
+
+	for i := 0; i < 200; i++ {
+		params := map[string]any{"chat_id": itoa(1000000 + i)} // 200 distinct users
+		if _, err := c.RequestWithContext(context.Background(), "t", "copyMessage", params, nil); err != nil {
+			t.Fatalf("send %d across many chats was refused: %v", i, err)
+		}
+	}
+
+	var total time.Duration
+	for _, d := range *slept {
+		total += d
+	}
+	// 200 messages spread across users is ~9s of real time at 22/s, and the limiter
+	// must not add more waiting than that to the dispatcher.
+	if total > 12*time.Second {
+		t.Errorf("200 sends across 200 chats cost %v of dispatcher time; too much", total)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/bot/ratelimit_test.go
+++ b/internal/bot/ratelimit_test.go
@@ -106,9 +106,11 @@ func TestFloodWaitPausesEverything(t *testing.T) {
 	if got := l.floodWaitRemaining(); got < 119*time.Second {
 		t.Fatalf("floodWaitRemaining = %v; want ~120s", got)
 	}
-	// Even a chat that has sent nothing is held back.
-	if w := l.reserve(999); w < 119*time.Second {
-		t.Errorf("a fresh chat got wait %v during a flood pause; want ~120s", w)
+	// reserve() reports PACING only, deliberately: folding the pause in here is what
+	// made one pause cascade into a lockup. The pause is enforced by the client, see
+	// TestBackpressureIsNotMistakenForATelegramFlood.
+	if w := l.reserve(999); w != 0 {
+		t.Errorf("reserve() returned %v for an idle chat; it must report pacing only", w)
 	}
 
 	// A LONGER wait extends it; a shorter one must not shorten it.
@@ -202,27 +204,66 @@ func TestSendsArePacedAtTheChannelRate(t *testing.T) {
 	}
 }
 
-// TestFailsFastWhenDebtStacks: with callers already queued — the real shape under
-// load, since background jobs send alongside the dispatcher — the wait grows past
-// the cap, and the call must fail fast rather than park the pipeline.
-func TestFailsFastWhenDebtStacks(t *testing.T) {
-	l, _, _ := newTestLimiter()
+// TestPacingNeverDropsAMessage is the regression test for the outage: back-pressure
+// must DELAY a send, never refuse it. Refusing meant a synthetic 429, which handleErr
+// treated as a Telegram flood, which paused everything, which made every later call
+// refuse too — the loop that muted the bot and stopped users answering.
+func TestPacingNeverDropsAMessage(t *testing.T) {
+	l, _, slept := newTestLimiter()
 	c := &limitedClient{inner: &fakeInner{}, limiter: l}
 	const channel = int64(-1002157529004)
 
-	// Stack debt without letting any time pass, as concurrent callers would.
-	for i := 0; i < 12; i++ {
+	for i := 0; i < 20; i++ { // stack deep debt, as concurrent callers would
 		l.reserve(channel)
 	}
+	if _, err := c.RequestWithContext(context.Background(), "t", "sendMessage",
+		map[string]any{"chat_id": "-1002157529004"}, nil); err != nil {
+		t.Fatalf("a deeply queued send was REFUSED (%v); pacing must delay, not drop", err)
+	}
+	for _, d := range *slept {
+		if d > maxInlineWait {
+			t.Errorf("slept %v, past the %v cap that keeps the dispatcher moving", d, maxInlineWait)
+		}
+	}
+}
 
+// TestBackpressureIsNotMistakenForATelegramFlood pins the distinction that broke
+// production: our own pause must never look like a 429.
+func TestBackpressureIsNotMistakenForATelegramFlood(t *testing.T) {
+	l, _, _ := newTestLimiter()
+	c := &limitedClient{inner: &fakeInner{}, limiter: l}
+
+	l.noteFloodWait(600) // Telegram really has paused us
 	_, err := c.RequestWithContext(context.Background(), "t", "sendMessage",
-		map[string]any{"chat_id": "-1002157529004"}, nil)
+		map[string]any{"chat_id": "12345"}, nil)
 	if err == nil {
-		t.Fatal("a deeply queued send was accepted; it would have parked the dispatcher")
+		t.Fatal("a send went out during a 600s Telegram pause")
+	}
+	if !errors.Is(err, errFloodPaused) {
+		t.Errorf("error = %v; want errFloodPaused", err)
 	}
 	var te *gotgbot.TelegramError
-	if !errors.As(err, &te) || te.Code != 429 {
-		t.Errorf("fail-fast error = %v; want a 429 so handleErr tells the user to retry", err)
+	if errors.As(err, &te) && te.Code == 429 {
+		t.Error("our own pause was reported as a 429 — this is the loop that muted the bot")
+	}
+	if got := l.floodWaitRemaining(); got > 601*time.Second {
+		t.Errorf("the pause grew to %v just from being observed", got)
+	}
+}
+
+// TestFloodPauseDoesNotSelfExtend: hammering a paused limiter must leave the deadline
+// exactly where Telegram put it.
+func TestFloodPauseDoesNotSelfExtend(t *testing.T) {
+	l, _, _ := newTestLimiter()
+	c := &limitedClient{inner: &fakeInner{}, limiter: l}
+	l.noteFloodWait(300)
+	before := l.floodWaitRemaining()
+	for i := 0; i < 25; i++ {
+		_, _ = c.RequestWithContext(context.Background(), "t", "sendMessage",
+			map[string]any{"chat_id": "12345"}, nil)
+	}
+	if after := l.floodWaitRemaining(); after > before {
+		t.Errorf("pause grew from %v to %v by being hit repeatedly; that is the lockup", before, after)
 	}
 }
 


### PR DESCRIPTION
Two production faults in the limiter, both mine. Production is on **v1.9.0** while this lands.

## 1. The mute (v2.0.0 / v2.0.1)

Back-pressure was signalled as a **synthetic `TelegramError{Code: 429}`**. `handleErr` can't tell that from Telegram's own, so it recorded a flood pause — *because of our own pause*. `reserve()` folded that pause into its wait, so every later call exceeded the cap, produced another synthetic 429, and extended the pause again.

Self-sustaining, and **invisible**: the v1.9.0 fix deliberately stopped logging 429s, so the bot sent nothing while the logs stayed clean. That's why it looked like the buttons had broken.

**Fixed:** pacing is a bounded delay that always sends. The only refusal is while Telegram itself has us paused, reported as `errFloodPaused` — a distinct sentinel, never a 429 — and `handleErr` handles it without touching `noteFloodWait`. `reserve()` no longer folds the pause in at all.

**Important:** I wrote this fix once already and it did **not** survive into the branch that merged as #26, so v2.0.1 shipped the bug again under a new tag. This time I verified by grep before tagging: `errFloodPaused` present in both files, **zero** synthetic `TelegramError` constructions.

## 2. The stall — "the bot stops responding when a user spams"

`maxInlineWait` was 3 seconds. The dispatcher is `MaxRoutines: 1`, so **every millisecond waited is a millisecond nobody else's update is processed.** One user pushing their 40/min allowance could park the pipeline for a minute at a time — the bot looked dead to everyone, which is exactly what you saw.

**Fixed:** 300ms. Still smooths the micro-bursts that cause most 429s, while keeping the worst case per update small enough that one flood cannot starve other users.

On spam not being silent: `allowSend` already caps a sender at 40/minute and replies "slow down" (`txtTooFast`), and the compose state is cleared — so those messages are answered, not dropped into a void. The silence you saw was the mute above, not the spam cap.

## Tests bounding the dispatcher cost

- `TestOneSpammerCannotStallTheBot` — a 40-message flood from one chat, asserting total dispatcher time stays bounded and no single wait exceeds the cap.
- `TestFloodFromManyUsersStaysResponsive` — 200 messages across 200 chats.
- `TestPacingNeverDropsAMessage` — 20 stacked reservations, the send still goes out.
- `TestBackpressureIsNotMistakenForATelegramFlood` — our pause is `errFloodPaused`, explicitly not a 429.
- `TestFloodPauseDoesNotSelfExtend` — 25 hits on a paused limiter leave the deadline where Telegram put it.

## What I still cannot promise

This paces sends and stops the bot muting or stalling. It is **not** a durable queue that guarantees eventual delivery of, say, 1000 queued messages — that needs sends moved off the dispatch path with their results plumbed back asynchronously, which touches every send site. I'm not bolting that on tonight; it's the change most likely to cause another outage. Worth doing as its own scoped piece of work.

## Verification

`go build`, `go vet`, `gofmt`, `go test -race -count=1 ./...` — green with a real PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)