### PR TITLE
fix(errors): a group the bot cannot post in is not an incident

### DIFF
--- a/internal/bot/prep.go
+++ b/internal/bot/prep.go
@@ -129,6 +129,12 @@ func (b *Bot) handleErr(tg *gotgbot.Bot, ctx *ext.Context, err error) error {
 		return nil
 	case errForbidden(err): // covers "bot was blocked by the user" / "not a member"
 		return nil
+	case errNoSendRights(err):
+		// The bot is in a group where it may not post. A permission fact about that
+		// chat, not a bug: logged once at INFO so it is discoverable, never filed as
+		// an incident (which would report every single message in that group).
+		slog.Info("cannot reply in this chat: no send rights", "chat", chatIDOf(ctx))
+		return nil
 	case errors.Is(err, errFloodPaused):
 		// OUR pause, honouring Telegram's. Must NOT call noteFloodWait: recording a
 		// pause because we are already paused is the loop that muted the bot.
@@ -175,6 +181,14 @@ func (b *Bot) handleErr(tg *gotgbot.Bot, ctx *ext.Context, err error) error {
 	default:
 		return err
 	}
+}
+
+// chatIDOf is the chat an update came from, 0 if unknown.
+func chatIDOf(ctx *ext.Context) int64 {
+	if ctx != nil && ctx.EffectiveChat != nil {
+		return ctx.EffectiveChat.Id
+	}
+	return 0
 }
 
 // command registers a private-chat command handler wrapped with prep. Used for

--- a/internal/bot/tgerr.go
+++ b/internal/bot/tgerr.go
@@ -137,3 +137,18 @@ func isFloodErr(err error) bool {
 	_, ok := errTooManyRequests(err)
 	return ok
 }
+
+// errNoSendRights: "Bad Request: not enough rights to send text messages to the
+// chat" (and the media variants).
+//
+// This is a FACT ABOUT A CHAT, not a fault. prep deliberately allows supergroups
+// (Python parity — the bot answers commands and the catch-all there), so once
+// somebody adds the bot to a group where members are restricted from posting, every
+// message in that group makes the catch-all try to reply and be refused. Treating
+// that as an incident filed one report per message into ERROR_CHAT_ID and tried to
+// reply to the user with a tracking code — a reply that also could not be sent.
+//
+// Same family as errForbidden: nothing to fix, nothing to page anyone about.
+func errNoSendRights(err error) bool {
+	return descContains(err, "not enough rights to send")
+}

--- a/internal/bot/tgerr_test.go
+++ b/internal/bot/tgerr_test.go
@@ -66,3 +66,36 @@ func TestErrorPredicates(t *testing.T) {
 		t.Error("isNetworkError should be false for telegram/db/plain errors")
 	}
 }
+
+// TestErrNoSendRightsIsBenign guards the classification that stops one restricted
+// group filling the error channel. Somebody adds the bot to a supergroup where
+// members cannot post; prep allows supergroups, so every message there makes the
+// catch-all try to reply and be refused. Filed as incidents that was one report per
+// message — plus a tracking-code reply that also could not be sent.
+func TestErrNoSendRightsIsBenign(t *testing.T) {
+	err := &gotgbot.TelegramError{
+		Method:      "sendMessage",
+		Code:        400,
+		Description: "Bad Request: not enough rights to send text messages to the chat",
+	}
+	if !errNoSendRights(err) {
+		t.Error("the real production error was not classified as a missing-rights error")
+	}
+	// It must not be mistaken for anything that IS actionable.
+	if errForbidden(err) {
+		t.Error("a 400 was classified as a 403")
+	}
+	if _, isFlood := errTooManyRequests(err); isFlood {
+		t.Error("a rights error was classified as a rate limit")
+	}
+	// Unrelated errors must not match, or real failures would be swallowed.
+	for _, other := range []error{
+		&gotgbot.TelegramError{Code: 400, Description: "Bad Request: message to copy not found"},
+		&gotgbot.TelegramError{Code: 403, Description: "Forbidden: bot was blocked by the user"},
+		&gotgbot.TelegramError{Code: 429, Description: "Too Many Requests: retry after 5"},
+	} {
+		if errNoSendRights(other) {
+			t.Errorf("%v was wrongly classified as a missing-rights error", other)
+		}
+	}
+}


### PR DESCRIPTION
## Your alert, diagnosed

`unable to sendMessage: Bad Request: not enough rights to send text messages to the chat` — 3 times in 18 hours.

From the logs, all three are **one supergroup** (`-1003765635633`) that somebody added the bot to, where members are **restricted from posting**. Three different senders, same chat.

`prep` deliberately allows supergroups (Python parity — the bot answers commands and the catch-all there). So every message in that group makes the catch-all try to reply "didn't understand", and Telegram refuses.

**Nothing is broken.** It's a permission fact about that chat.

## Why it was noise worth fixing

It was filed as a *tracked incident*, which posts a report to `ERROR_CHAT_ID` **and** tries to reply a tracking code to the user — a reply that also can't be sent, for the same reason. A busy restricted group would have produced one report per message.

Now classified benign alongside `errForbidden`, logged once at INFO with the chat id so it stays discoverable. The test pins that it is **not** confused with a 403, a 429, or an unrelated 400, so real failures keep surfacing.

**If you want the bot to stop replying in that group entirely**, the clean fix is to remove it from the group or give it send rights — I didn't change `prep`'s supergroup behaviour, since that's deliberate Python parity and other groups may rely on it.

## The 18-hour review you asked for

`v2.1.0`, up 18h, **0 restarts**:

| | Before | v2.1.0 (18h) |
|---|---|---|
| Messages delivered | — | **3,392** |
| Answers | — | **288** |
| Total errors | 321 in 9h | **9** |
| Telegram 429s | 321 | **1** |
| Flood pauses needed | — | **0** |

The mute is gone, the stall is gone, and the limiter cut 429s from ~35/hour to ~0.05/hour. The remaining 9 errors are the 3 above plus 6 benign ones (a user deleting a message before it was copied).

## Verification note

Verified by **CI this round, not locally** — Docker Desktop stopped responding on my machine. CI runs the same `build / vet / gofmt / go test -race` gate. The DB integration tests skip there, and this change touches neither the database nor the limiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)