### PR TITLE
feat(antispam): bound what one victim can be made to receive

### DIFF
--- a/internal/bot/antispam_test.go
+++ b/internal/bot/antispam_test.go
@@ -1,0 +1,167 @@
+package bot
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestGlobalSendLimit covers the total-output cap: a normal person never reaches it,
+// an automated flood does.
+func TestGlobalSendLimit(t *testing.T) {
+	u := &userData{}
+
+	// Spread across many targets so only the GLOBAL limit can bite.
+	for i := 0; i < sendRateMax; i++ {
+		allowed, _ := u.allowSendTo("target" + strconv.Itoa(i))
+		if !allowed {
+			t.Fatalf("send %d was blocked below the global limit of %d", i, sendRateMax)
+		}
+	}
+	allowed, warn := u.allowSendTo("targetN")
+	if allowed {
+		t.Errorf("send %d was allowed past the global limit", sendRateMax+1)
+	}
+	if !warn {
+		t.Error("the first block did not warn the user; they would see nothing happen")
+	}
+}
+
+// TestPerTargetLimitProtectsOneVictim is the important one. The global limit alone
+// permits 40 messages a minute all aimed at the SAME person, which is the
+// harassment anonymity makes possible. This bounds what one inbox can be made to
+// receive.
+func TestPerTargetLimitProtectsOneVictim(t *testing.T) {
+	u := &userData{}
+	const victim = "1988454449"
+
+	for i := 0; i < perTargetMax; i++ {
+		if allowed, _ := u.allowSendTo(victim); !allowed {
+			t.Fatalf("message %d to one person was blocked below the per-target limit of %d", i, perTargetMax)
+		}
+	}
+	if allowed, _ := u.allowSendTo(victim); allowed {
+		t.Errorf("message %d to the same person was allowed; a victim can be flooded", perTargetMax+1)
+	}
+
+	// Crucially, a DIFFERENT recipient is still reachable: the sender is not banned
+	// outright, only stopped from piling on one person.
+	if allowed, _ := u.allowSendTo("5118145008"); !allowed {
+		t.Error("a different recipient was blocked; the per-target limit must not act as a global ban")
+	}
+}
+
+// TestWarnIsRateLimited: a flooder tripping the limit hundreds of times must not
+// receive hundreds of replies. Each reply is an API call, so warning every time
+// would make the anti-spam measure a flood of its own — and give an automated
+// flooder a steady stream of responses.
+func TestWarnIsRateLimited(t *testing.T) {
+	u := &userData{}
+	const victim = "1988454449"
+
+	for i := 0; i < perTargetMax; i++ {
+		u.allowSendTo(victim)
+	}
+
+	warned := 0
+	for i := 0; i < 200; i++ {
+		allowed, warn := u.allowSendTo(victim)
+		if allowed {
+			t.Fatalf("attempt %d slipped past the limit", i)
+		}
+		if warn {
+			warned++
+		}
+	}
+	if warned != 1 {
+		t.Errorf("a 200-attempt flood produced %d warnings; want exactly 1 inside the cooldown", warned)
+	}
+}
+
+// TestLimitsRecoverAfterTheWindow: the limits are a speed bump, not a ban. A user
+// who waits must be able to talk again, or a burst would silence them for good.
+func TestLimitsRecoverAfterTheWindow(t *testing.T) {
+	u := &userData{}
+	const victim = "1988454449"
+
+	for i := 0; i < perTargetMax; i++ {
+		u.allowSendTo(victim)
+	}
+	if allowed, _ := u.allowSendTo(victim); allowed {
+		t.Fatal("the per-target limit did not engage")
+	}
+
+	// Age every recorded send past the window, as real time would.
+	shift := int64(sendRateWindow) + int64(time.Second)
+	for i := range u.sendTimes {
+		u.sendTimes[i] -= shift
+	}
+	for tgt, times := range u.perTarget {
+		for i := range times {
+			times[i] -= shift
+		}
+		u.perTarget[tgt] = times
+	}
+
+	if allowed, _ := u.allowSendTo(victim); !allowed {
+		t.Error("the user was still blocked after the window elapsed; the limit is acting as a ban")
+	}
+}
+
+// TestCancelCannotResetTheLimit: clear() wipes the conversation, and a flooder must
+// not be able to dodge the limit by cancelling between messages.
+func TestCancelCannotResetTheLimit(t *testing.T) {
+	u := &userData{}
+	const victim = "1988454449"
+
+	for i := 0; i < perTargetMax; i++ {
+		u.allowSendTo(victim)
+	}
+	u.clear()
+
+	if allowed, _ := u.allowSendTo(victim); allowed {
+		t.Error("clearing the conversation reset the rate limit; /cancel would defeat the anti-spam")
+	}
+}
+
+// TestStaleTargetsAreForgotten: perTarget must not grow for the life of the process.
+// A user who messages many people over hours would otherwise accumulate an entry per
+// recipient forever.
+func TestStaleTargetsAreForgotten(t *testing.T) {
+	u := &userData{}
+	for i := 0; i < 50; i++ {
+		u.allowSendTo("t" + strconv.Itoa(i))
+	}
+	if len(u.perTarget) == 0 {
+		t.Fatal("no targets were recorded at all")
+	}
+
+	// Age everything past the window, then make one more call to trigger the sweep.
+	shift := int64(sendRateWindow) + int64(time.Second)
+	for tgt, times := range u.perTarget {
+		for i := range times {
+			times[i] -= shift
+		}
+		u.perTarget[tgt] = times
+	}
+	u.allowSendTo("fresh")
+
+	if len(u.perTarget) != 1 {
+		t.Errorf("perTarget holds %d entries after they all expired; want just the fresh one", len(u.perTarget))
+	}
+}
+
+// TestEmptyTargetStillCountsGlobally guards the path where the target is unknown
+// (a malformed or cancelled flow): it must still consume global budget, or that
+// becomes a way to send without limit.
+func TestEmptyTargetStillCountsGlobally(t *testing.T) {
+	u := &userData{}
+	for i := 0; i < sendRateMax; i++ {
+		if allowed, _ := u.allowSendTo(""); !allowed {
+			t.Fatalf("send %d with no target was blocked early", i)
+		}
+	}
+	if allowed, _ := u.allowSendTo(""); allowed {
+		t.Error("sends with no target ignore the global limit; that is an unlimited path")
+	}
+}

--- a/internal/bot/antispam_test.go
+++ b/internal/bot/antispam_test.go
@@ -136,15 +136,24 @@ func TestStaleTargetsAreForgotten(t *testing.T) {
 		t.Fatal("no targets were recorded at all")
 	}
 
-	// Age everything past the window, then make one more call to trigger the sweep.
+	// Age EVERYTHING past the window — the global list as well as the per-target
+	// ones. Ageing only the per-target entries left 50 fresh global timestamps, over
+	// the 40 cap, so the next call was blocked and recorded nothing.
 	shift := int64(sendRateWindow) + int64(time.Second)
+	for i := range u.sendTimes {
+		u.sendTimes[i] -= shift
+	}
 	for tgt, times := range u.perTarget {
 		for i := range times {
 			times[i] -= shift
 		}
 		u.perTarget[tgt] = times
 	}
-	u.allowSendTo("fresh")
+
+	// One more call triggers the sweep and records itself.
+	if allowed, _ := u.allowSendTo("fresh"); !allowed {
+		t.Fatal("a send after the window elapsed was blocked")
+	}
 
 	if len(u.perTarget) != 1 {
 		t.Errorf("perTarget holds %d entries after they all expired; want just the fresh one", len(u.perTarget))

--- a/internal/bot/sendmsg.go
+++ b/internal/bot/sendmsg.go
@@ -72,17 +72,28 @@ func (b *Bot) sendMsgCore(ctx *ext.Context, userid string) (string, error) {
 	msg := ctx.EffectiveMessage
 	ud := b.ud(ctx)
 
-	// Outbound rate limit (generous): caps an automated anonymous-message flood
-	// without affecting a human composing messages. The send is dropped and the
-	// user is told to slow down; END the compose (no partial send).
-	if !ud.allowSend() {
-		slog.Info("send dropped: rate-limited", "userid", userid, "kind", kindOf(msg))
-		_ = b.replyText(ctx, txtTooFast)
+	targetUID := ud.d.targetUID
+
+	// Anti-spam, checked before anything is sent. Two limits: total output from this
+	// account, and how much a SINGLE recipient can be made to receive — the second
+	// is the one that protects a victim, since the harassment anonymity enables is
+	// aimed at one inbox.
+	//
+	// warn is rate-limited separately: replying to every blocked attempt would cost
+	// one API call per attempt, turning the anti-spam measure into its own flood.
+	// When it is false the attempt is dropped silently, which is also the right
+	// answer for an automated flooder — it gets nothing back to react to.
+	allowed, warn := ud.allowSendTo(targetUID)
+	if !allowed {
+		slog.Info("send dropped: rate-limited",
+			"userid", userid, "kind", kindOf(msg), "warned", warn)
+		if warn {
+			_ = b.replyText(ctx, txtTooFast)
+		}
 		ud.clear()
 		return delNone, nil
 	}
 
-	targetUID := ud.d.targetUID
 	targetCid := ud.d.targetCid
 	targetMid := ud.d.replyTo
 	wasChannelReply := ud.d.channelReply

--- a/internal/bot/userdata.go
+++ b/internal/bot/userdata.go
@@ -29,6 +29,18 @@ type userData struct {
 	// Guarded by mu (prep holds it for the whole handler).
 	sendTimes []int64
 
+	// perTarget: recent send times PER RECIPIENT. The global limit above bounds
+	// total output, but the harassment vector on an anonymous bot is one person
+	// flooding ONE victim — 40/min all aimed at the same inbox is still 40 messages
+	// they cannot stop. Keyed by target uid, same nano timestamps, same lifetime as
+	// sendTimes so cancelling cannot reset it.
+	perTarget map[string][]int64
+
+	// lastWarn: when the user was last told to slow down. A flooder tripping the
+	// limit hundreds of times must not get hundreds of replies — each one is an API
+	// call, so warning on every trip turns the anti-spam measure into its own flood.
+	lastWarn int64
+
 	// lastAccess: when this entry was last fetched. The userStore sweep evicts
 	// long-idle entries to bound memory under a large/hostile population.
 	// Guarded by the userStore mutex (set in get, read in sweep).
@@ -42,25 +54,77 @@ type userData struct {
 const (
 	sendRateMax    = 40
 	sendRateWindow = time.Minute
+
+	// perTargetMax bounds messages to ONE recipient in the same window. A human
+	// conversation never needs this many in a minute; a flood aimed at one person
+	// does. This is the limit that actually protects a victim.
+	perTargetMax = 8
+
+	// warnCooldown is how often a rate-limited user is told to slow down. Replying
+	// to every blocked attempt would cost one API call per attempt, which is exactly
+	// the load the limit exists to prevent.
+	warnCooldown = 30 * time.Second
 )
 
-// allowSend reports whether this user may send another anonymous message now
-// (sliding window). The caller holds u.mu (prep does).
-func (u *userData) allowSend() bool {
-	now := time.Now().UnixNano()
-	cutoff := now - int64(sendRateWindow)
-	kept := u.sendTimes[:0]
-	for _, t := range u.sendTimes {
+// prune drops timestamps older than the window and returns what is left.
+func prune(times []int64, cutoff int64) []int64 {
+	kept := times[:0]
+	for _, t := range times {
 		if t >= cutoff {
 			kept = append(kept, t)
 		}
 	}
-	u.sendTimes = kept
-	if len(kept) >= sendRateMax {
-		return false
+	return kept
+}
+
+// allowSendTo reports whether this user may send another anonymous message to
+// target right now, and whether the caller should say so.
+//
+// Two limits, because they catch different abuse:
+//   - the global one bounds total output from this account;
+//   - the per-target one bounds what a single VICTIM can be made to receive, which
+//     is the harassment the anonymity makes possible in the first place.
+//
+// warn is true at most once per warnCooldown. A flooder that trips the limit two
+// hundred times must not receive two hundred replies: each is an API call, and
+// answering every attempt would make the anti-spam measure a flood of its own.
+//
+// The caller holds u.mu (prep does).
+func (u *userData) allowSendTo(target string) (allowed, warn bool) {
+	now := time.Now().UnixNano()
+	cutoff := now - int64(sendRateWindow)
+
+	u.sendTimes = prune(u.sendTimes, cutoff)
+
+	if u.perTarget == nil {
+		u.perTarget = make(map[string][]int64)
 	}
+	// Prune every target, not just this one, so an abandoned conversation cannot
+	// keep its slice alive for the lifetime of the process.
+	for t, times := range u.perTarget {
+		if kept := prune(times, cutoff); len(kept) == 0 {
+			delete(u.perTarget, t)
+		} else {
+			u.perTarget[t] = kept
+		}
+	}
+
+	overGlobal := len(u.sendTimes) >= sendRateMax
+	overTarget := target != "" && len(u.perTarget[target]) >= perTargetMax
+
+	if overGlobal || overTarget {
+		if now-u.lastWarn >= int64(warnCooldown) {
+			u.lastWarn = now
+			return false, true
+		}
+		return false, false
+	}
+
 	u.sendTimes = append(u.sendTimes, now)
-	return true
+	if target != "" {
+		u.perTarget[target] = append(u.perTarget[target], now)
+	}
+	return true, false
 }
 
 // convData holds exactly the keys the Python handlers stored in user_data.

--- a/internal/bot/userdata_test.go
+++ b/internal/bot/userdata_test.go
@@ -1,18 +1,20 @@
 package bot
 
 import (
+	"strconv"
 	"testing"
 	"time"
 )
 
 func TestAllowSendCap(t *testing.T) {
 	u := &userData{}
+	// Distinct targets, so only the GLOBAL cap can be the thing that blocks.
 	for i := 0; i < sendRateMax; i++ {
-		if !u.allowSend() {
+		if allowed, _ := u.allowSendTo("t" + strconv.Itoa(i)); !allowed {
 			t.Fatalf("send %d/%d should be allowed", i+1, sendRateMax)
 		}
 	}
-	if u.allowSend() {
+	if allowed, _ := u.allowSendTo("tN"); allowed {
 		t.Fatal("send over the cap should be blocked")
 	}
 }
@@ -23,7 +25,7 @@ func TestAllowSendWindowAgesOut(t *testing.T) {
 	for i := 0; i < sendRateMax; i++ {
 		u.sendTimes = append(u.sendTimes, old)
 	}
-	if !u.allowSend() {
+	if allowed, _ := u.allowSendTo("t"); !allowed {
 		t.Fatal("timestamps outside the window should age out; send should be allowed")
 	}
 	if len(u.sendTimes) != 1 {


### PR DESCRIPTION
Stage 1: the anti-spam half. The durable queue is stage 2 (needs DB integration tests; Docker is down locally, LotusPay is the safe host for them).

## The gap

The existing limit capped a sender at 40 messages/minute in TOTAL. That still permits 40 aimed at the SAME person — precisely the harassment anonymity enables, since the recipient cannot tell who it is or make it stop.

## What changed

**A per-recipient cap of 8/minute** alongside the global one. A sender who trips it can still message anyone else: it stops piling on one inbox rather than banning the account.

**The warning no longer floods.** Every blocked attempt used to reply 'slow down', so a flooder trying 200 times got 200 replies — 200 API calls spent on the very resource the limit protects, and a steady stream of responses for an automated flooder to react to. It now warns at most once per 30s; blocked attempts in between are dropped silently.

Both counters live outside convData so /cancel cannot reset them (tested — otherwise cancelling between messages defeats the whole thing). Expired per-target entries are swept each call so the map cannot grow for the process lifetime.

## Tests

- global cap engages; a normal user never reaches it
- per-target cap protects one victim, while a different recipient stays reachable
- 200 blocked attempts produce exactly 1 warning
- limits recover after the window (a speed bump, not a ban)
- /cancel cannot reset the limit
- stale per-target entries are forgotten
- an unknown target still consumes global budget (otherwise that is an unlimited path)

## Verification

CI is the gate this round: Docker is down locally and the Go toolchain is blocked by Application Control, so I have no local build. These tests are pure in-memory logic with no database, so CI's build/vet/gofmt/-race covers them completely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)